### PR TITLE
fix(ci): exclude pre-release tags when computing release notes range

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,11 @@ jobs:
           set -euo pipefail
 
           TAG="v${{ steps.version.outputs.VERSION }}"
-          PREV_TAG=$(git tag --sort=-version:refname | head -1)
+          # Only compare against stable tags (exclude draft/alpha/beta/rc pre-releases)
+          PREV_TAG=$(git tag --sort=-version:refname \
+            | grep -v -E '\-(draft|alpha|beta|rc)' \
+            | grep -v "^${TAG}$" \
+            | head -1)
 
           if [ -z "$PREV_TAG" ]; then
             NOTES=$(git log --oneline --no-decorate | head -20)


### PR DESCRIPTION
### Context

Release notes in v0.2.0 duplicated all commits from v0.1.0 because the PREV_TAG selection was picking v0.1.0-draft (a pre-release) instead of v0.1.0 (the last stable tag).

### Description

- **Module**: .github/workflows/release.yml
- **Odoo Version**: N/A
- **Breaking Change**: No

Fix the PREV_TAG selection logic to exclude pre-release tags (draft, alpha, beta, rc) before picking the previous stable tag as the comparison base for release notes.

### Steps to Review

On the next release (v0.3.0), verify that the release notes only list commits made after v0.2.0, not duplicated history from v0.1.0.

### Checklist

- [x] Fix is minimal and targeted.
- [x] No behavior change for stable releases.
- [x] Pre-release tags are still supported as release artifacts.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.