### PR TITLE
docs(contributing): simplify agent ownership model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,12 +95,12 @@ This section defines which AI agent owns each skill and their branch convention.
 
 ### Agent Roster
 
-| Agent | ID | Role | Skills Owned | Branch Pattern |
-|-------|----|------|--------------|----------------|
-| Claude Code | `claude-code` | Programming | [skills/odoo-commit/](skills/odoo-commit/), [skills/odoo-pr/](skills/odoo-pr/), [skills/odoo-ci/](skills/odoo-ci/), [skills/odoo-changelog/](skills/odoo-changelog/), skills/odoo-orm/, skills/odoo-module/ | `agent/claude-code/*` |
-| OpenCode | `opencode` | Programming | skills/odoo-controllers/, skills/odoo-testing/, skills/odoo-security/, skills/odoo-debug/ | `agent/opencode/*` |
-| Codex | `codex` | Programming | skills/odoo-data/, skills/odoo-wizards/, skills/odoo-cron/, skills/odoo-performance/, skills/odoo-migration/ | `agent/codex/*` |
-| Gemini CLI | `gemini-cli` | Documentation & design | skills/odoo-views/, skills/odoo-owl/, skills/odoo-qweb/, skills/odoo-v17-changes/, skills/odoo-v18-changes/, skills/odoo-docker/, skills/odoo-mail/ | `agent/gemini-cli/*` |
+| Agent | ID | Role | Skill Category | Branch Pattern |
+|-------|----|------|----------------|----------------|
+| Claude Code | `claude-code` | Programming | All programming & infrastructure skills | `agent/claude-code/*` |
+| OpenCode | `opencode` | Programming | All programming & infrastructure skills | `agent/opencode/*` |
+| Codex | `codex` | Programming | All programming & infrastructure skills | `agent/codex/*` |
+| Gemini CLI | `gemini-cli` | Documentation & design | XML views, OWL, QWeb, Markdown guides | `agent/gemini-cli/*` |
 | Geraldow | `geraldow` | Author & reviewer | All frozen files, PRD, README | `develop` (direct) |
 
 ### Frozen Files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,41 +26,45 @@ All contributors — human and AI — follow the same rules defined in this docu
 
 ## 2. Skill Ownership
 
-Each skill is owned by one contributor. Only the owner may open PRs that modify files inside that skill's folder.
+Skills are grouped by **category**, not by individual agent. Any programming agent (`claude-code`, `opencode`, `codex`) may work on any programming skill. Only `gemini-cli` handles documentation & design skills.
 
-### Programming skills (Python / backend)
+### Programming skills (Python / backend / infrastructure)
 
-| Skill | Owner | Description |
-|-------|-------|-------------|
-| `odoo-commit` | `claude-code` | Git commit conventions |
-| `odoo-pr` | `claude-code` | Pull Request workflow |
-| `odoo-ci` | `claude-code` | CI/CD and GitHub Actions |
-| `odoo-changelog` | `claude-code` | CHANGELOG management |
-| `odoo-orm` | `claude-code` | Models, fields, ORM patterns |
-| `odoo-module` | `claude-code` | Module structure and manifest |
-| `odoo-controllers` | `opencode` | HTTP routes and JSON-RPC controllers |
-| `odoo-testing` | `opencode` | Python tests for Odoo |
-| `odoo-security` | `opencode` | Access rights and security rules |
-| `odoo-debug` | `opencode` | Debugging tools and shell usage |
-| `odoo-data` | `codex` | Data and demo XML files |
-| `odoo-wizards` | `codex` | TransientModel wizards |
-| `odoo-cron` | `codex` | Scheduled actions |
-| `odoo-performance` | `codex` | ORM optimization and N+1 patterns |
-| `odoo-migration` | `codex` | Module migration between Odoo versions |
+**Eligible agents**: `claude-code`, `opencode`, `codex`
 
-### Documentation & design skills (.md, .mdx, XML views, diagrams)
+| Skill | Description |
+|-------|-------------|
+| `odoo-commit` | Git commit conventions |
+| `odoo-pr` | Pull Request workflow |
+| `odoo-ci` | CI/CD and GitHub Actions |
+| `odoo-changelog` | CHANGELOG management |
+| `odoo-orm` | Models, fields, ORM patterns |
+| `odoo-module` | Module structure and manifest |
+| `odoo-controllers` | HTTP routes and JSON-RPC controllers |
+| `odoo-testing` | Python tests for Odoo |
+| `odoo-security` | Access rights and security rules |
+| `odoo-debug` | Debugging tools and shell usage |
+| `odoo-data` | Data and demo XML files |
+| `odoo-wizards` | TransientModel wizards |
+| `odoo-cron` | Scheduled actions |
+| `odoo-performance` | ORM optimization and N+1 patterns |
+| `odoo-migration` | Module migration between Odoo versions |
+| `odoo-docker` | Docker setup for Odoo |
+| `odoo-mail` | mail.thread / Chatter integration |
 
-| Skill | Owner | Description |
-|-------|-------|-------------|
-| `odoo-views` | `gemini-cli` | XML views (form, tree, kanban, search) |
-| `odoo-owl` | `gemini-cli` | OWL components (v17+) |
-| `odoo-qweb` | `gemini-cli` | QWeb templates and PDF reports |
-| `odoo-v17-changes` | `gemini-cli` | v16→v17 migration guide |
-| `odoo-v18-changes` | `gemini-cli` | v17→v18 migration guide |
-| `odoo-docker` | `gemini-cli` | Docker setup for Odoo |
-| `odoo-mail` | `gemini-cli` | mail.thread / Chatter integration |
+### Documentation & design skills (XML views, OWL, QWeb, Markdown)
 
-> If you need a skill assigned to you, open an Issue with the label `skill-request`.
+**Eligible agent**: `gemini-cli` only
+
+| Skill | Description |
+|-------|-------------|
+| `odoo-views` | XML views (form, tree, kanban, search) |
+| `odoo-owl` | OWL components (v17+) |
+| `odoo-qweb` | QWeb templates and PDF reports |
+| `odoo-v17-changes` | v16→v17 migration guide |
+| `odoo-v18-changes` | v17→v18 migration guide |
+
+> If you need a new skill category, open an Issue with the label `skill-request`.
 
 ---
 
@@ -172,7 +176,7 @@ Before opening a PR for a new skill, verify:
 
 ## 7. Code of Conduct
 
-- Respect ownership boundaries — do not modify another agent's skill files
+- Respect category boundaries — programming agents do not modify documentation & design skills, and vice versa
 - Keep PRs focused — one skill per PR
 - If you discover a bug in another agent's skill, open an Issue rather than fixing it directly
 - All contributions are released under the MIT License


### PR DESCRIPTION
### Context

Simplifies the multi-agent coordination model defined in `CONTRIBUTING.md` and `AGENTS.md`. The previous per-skill ownership was too rigid for parallel work.

### Description

- **Scope**: Infrastructure / documentation only
- **Odoo Version**: N/A
- **Breaking Change**: No

### Changes

- `CONTRIBUTING.md` — Ownership is now by category: any programming agent (`claude-code`, `opencode`, `codex`) may work on any programming skill. `gemini-cli` exclusive to views, OWL, QWeb, Markdown guides
- `AGENTS.md` — Agent Roster updated to reflect category-based model
- `odoo-docker` and `odoo-mail` moved from Gemini → Programming

### Odoo Version Compatibility

- [x] N/A — Not version-sensitive

### Steps to Review

1. Read `CONTRIBUTING.md` Section 2 — two categories: Programming and Documentation & Design
2. Read `AGENTS.md` Section 6 — Agent Roster shows category, not individual skills

### Checklist

- [x] No deprecated API used
- [x] Branch is up to date with `develop`
- [x] Commits follow Conventional Commits

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT License.