### PR TITLE
fix(ci): add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
### Context

The release workflow only had `push: branches: main` as trigger. When a squash merge to main doesn't auto-trigger the workflow (edge case with GitHub Actions), there was no way to manually re-run it. This adds `workflow_dispatch` to allow manual recovery.

### Description

- Add `workflow_dispatch` trigger to `release.yml`

- **Module**: N/A — CI only
- **Odoo Version**: N/A
- **Breaking Change**: No

### Odoo Version Compatibility

- [x] N/A — Not version-sensitive

### Steps to Review

1. Merge to develop → main
2. Go to Actions → Release — Publish Skill Library → Run workflow

### Checklist

- [x] No deprecated API used
- [x] OCA naming conventions followed

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the applicable module license (LGPL-3 or AGPL-3).