### PR TITLE
fix(ci): use pull_request closed event to fix squash merge trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release — Publish Skill Library
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - main
   workflow_dispatch:
@@ -13,6 +15,7 @@ jobs:
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### Context

GitHub Actions does not reliably fire the `push` event when a PR is merged via **squash and merge** from the GitHub UI. This caused the release workflow to silently skip on PRs #39, #41, and #43.

Fix: change trigger from `push: branches: main` to `pull_request: types: [closed] branches: main` with a job condition `github.event.pull_request.merged == true`. This is the GitHub-recommended approach for post-merge automation.

### Description

- Change release trigger to `pull_request: closed` + merged check
- Keep `workflow_dispatch` as manual fallback

- **Breaking Change**: No — release logic unchanged, only trigger mechanism

### Odoo Version Compatibility

- [x] N/A — Not version-sensitive

### Steps to Review

1. Merge this PR to develop → main via squash and merge
2. Verify release workflow triggers automatically

### Checklist

- [x] No deprecated API used
- [x] CI checks pass

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the applicable module license (LGPL-3 or AGPL-3).