### PR TITLE
feat(security): add odoo-security skill for v16/v17/v18

### DIFF
--- a/skills/odoo-security/SKILL.md
+++ b/skills/odoo-security/SKILL.md
@@ -37,11 +37,11 @@ Load this skill when:
 
 Read `__manifest__.py` and parse the `version` field: `"17.0.1.0.0"` → major version `17`.
 
-| Version | Key Security Change |
-|---|---|
-| **v16** | `ir.rule` has a `global` boolean field |
+| Version | Key Security Change                                                    |
+| ------- | ---------------------------------------------------------------------- |
+| **v16** | `ir.rule` has a `global` boolean field                                 |
 | **v17** | `global` field removed — a rule with no groups is automatically global |
-| **v18** | Same as v17 |
+| **v18** | Same as v17                                                            |
 
 ---
 
@@ -106,7 +106,7 @@ my_module/
 
 ### Column order (positional — never reorder)
 
-```
+```csv
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 ```
 
@@ -120,13 +120,13 @@ access_sale_custom_order_manager,sale_custom.order manager,model_sale_custom_ord
 
 ### Column reference
 
-| Column | Value Pattern | Notes |
-|---|---|---|
-| `id` | `access_<model_underscore>_<group>` | Must be unique |
-| `name` | `<module>.<model> <group>` | Human-readable only |
+| Column        | Value Pattern                       | Notes                             |
+| ------------- | ----------------------------------- | --------------------------------- |
+| `id`          | `access_<model_underscore>_<group>` | Must be unique                    |
+| `name`        | `<module>.<model> <group>`          | Human-readable only               |
 | `model_id:id` | `model_<model_dots_as_underscores>` | `sale.order` → `model_sale_order` |
-| `group_id:id` | `<module>.group_<module>_<role>` | Module prefix is required |
-| `perm_*` | `1` or `0` | Integer — never `True`/`False` |
+| `group_id:id` | `<module>.group_<module>_<role>`    | Module prefix is required         |
+| `perm_*`      | `1` or `0`                          | Integer — never `True`/`False`    |
 
 ---
 
@@ -224,21 +224,21 @@ access_sale_custom_order_manager,sale_custom.order manager,model_sale_custom_ord
 
 ### Available context variables in `domain_force`
 
-| Variable | Type | Description |
-|---|---|---|
-| `user` | `res.users` recordset | Current logged-in user |
-| `time` | Python `time` module | For date-based conditions |
-| `company_ids` | `list[int]` | IDs of user's allowed companies |
+| Variable      | Type                  | Description                     |
+| ------------- | --------------------- | ------------------------------- |
+| `user`        | `res.users` recordset | Current logged-in user          |
+| `time`        | Python `time` module  | For date-based conditions       |
+| `company_ids` | `list[int]`           | IDs of user's allowed companies |
 
 ---
 
 ## Assets
 
-| File | Use Case |
-|---|---|
-| [`assets/access-template.csv`](assets/access-template.csv) | Drop-in `ir.model.access.csv` with two-tier permissions |
-| [`assets/groups-template.xml`](assets/groups-template.xml) | Module category + User/Manager group definitions |
-| [`assets/record-rule-template.xml`](assets/record-rule-template.xml) | Own-records rule + multi-company rule (v17+ syntax) |
+| File                                                                 | Use Case                                                |
+| -------------------------------------------------------------------- | ------------------------------------------------------- |
+| [`assets/access-template.csv`](assets/access-template.csv)           | Drop-in `ir.model.access.csv` with two-tier permissions |
+| [`assets/groups-template.xml`](assets/groups-template.xml)           | Module category + User/Manager group definitions        |
+| [`assets/record-rule-template.xml`](assets/record-rule-template.xml) | Own-records rule + multi-company rule (v17+ syntax)     |
 
 ---
 
@@ -348,7 +348,7 @@ Setting up ACL without record rules means all users with access see **all rows**
 
 ## References
 
-| Resource | Description |
-|---|---|
-| [`references/security-attributes.md`](references/security-attributes.md) | Full compatibility table v16/v17/v18, CSV column reference, base groups |
-| [Odoo Security Documentation](https://www.odoo.com/documentation/17.0/developer/reference/backend/security.html) | Official access rights and record rules reference |
+| Resource                                                                                                         | Description                                                             |
+| ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| [`references/security-attributes.md`](references/security-attributes.md)                                         | Full compatibility table v16/v17/v18, CSV column reference, base groups |
+| [Odoo Security Documentation](https://www.odoo.com/documentation/17.0/developer/reference/backend/security.html) | Official access rights and record rules reference                       |

--- a/skills/odoo-security/SKILL.md
+++ b/skills/odoo-security/SKILL.md
@@ -1,0 +1,354 @@
+---
+name: odoo-security
+description: >
+  Teaches AI agents to write correct, version-aware Odoo security artifacts:
+  ir.model.access.csv, ir.rule record rules, and res.groups definitions for
+  Odoo v16, v17, and v18.
+metadata:
+  author: Geraldow
+  version: "1.0.0"
+  supported_versions: ["16", "17", "18"]
+  detect_from: "__manifest__.py"
+  skill_id: ODSK-SKL-SEC
+auto_invoke:
+  - "Adding security groups or access rules"
+  - "Creating ir.model.access.csv"
+  - "Defining record rules or ir.rule"
+  - "Writing ir.rule domain_force"
+  - "Creating res.groups XML"
+  - "Setting up module security folder"
+---
+
+# odoo-security
+
+## When to Use
+
+Load this skill when:
+
+- Creating or editing `security/ir.model.access.csv`
+- Defining `res.groups` records in XML
+- Writing `ir.rule` record rules with `domain_force`
+- Setting up the `security/` folder structure for a new module
+- Migrating security files from Odoo v16 to v17/v18
+
+---
+
+## Version Detection
+
+Read `__manifest__.py` and parse the `version` field: `"17.0.1.0.0"` → major version `17`.
+
+| Version | Key Security Change |
+|---|---|
+| **v16** | `ir.rule` has a `global` boolean field |
+| **v17** | `global` field removed — a rule with no groups is automatically global |
+| **v18** | Same as v17 |
+
+---
+
+## Critical Rules
+
+### [v17+] NEVER set `global` on `ir.rule`
+
+```xml
+<!-- ❌ WRONG — global field was removed in v17, raises ValueError -->
+<field name="global" eval="True"/>
+
+<!-- ✅ CORRECT — omit groups entirely for a global rule in v17+ -->
+<!-- A rule with no groups m2m is automatically applied to all users -->
+```
+
+### NEVER omit `group_id:id` in the CSV without intent
+
+```csv
+# ❌ DANGEROUS — blank group_id means ALL users. Document this explicitly.
+access_my_model_all,my.model all,model_my_model,,1,0,0,0
+
+# ✅ SAFER — assign a group
+access_my_model_user,my.model user,model_my_model,my_module.group_my_module_user,1,0,0,0
+```
+
+### NEVER mix up ACL vs record rules
+
+- **`ir.model.access.csv`** → table-level (can the user access this model at all?)
+- **`ir.rule`** → row-level (which specific records can the user see/edit?)
+- Both are required for proper data isolation. ACL without record rules = user sees all rows.
+
+---
+
+## Folder Structure Pattern
+
+```text
+my_module/
+├── __manifest__.py
+└── security/
+    ├── groups.xml              ← Define res.groups here
+    ├── ir.model.access.csv     ← Table-level permissions
+    └── ir_rule.xml             ← Row-level record rules
+```
+
+### Manifest load order (critical)
+
+```python
+# __manifest__.py
+'data': [
+    'security/groups.xml',          # 1. Groups FIRST — CSV references them
+    'security/ir.model.access.csv', # 2. ACL SECOND — references groups
+    'security/ir_rule.xml',         # 3. Rules THIRD — references models and groups
+    'views/my_model_views.xml',     # 4. Views LAST
+],
+```
+
+> Loading `ir.model.access.csv` before `groups.xml` raises a `ManyToMany` foreign key error at install time.
+
+---
+
+## `ir.model.access.csv` Pattern
+
+### Column order (positional — never reorder)
+
+```
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+```
+
+### Two-tier permission example
+
+```csv
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sale_custom_order_user,sale_custom.order user,model_sale_custom_order,sale_custom.group_sale_custom_user,1,0,0,0
+access_sale_custom_order_manager,sale_custom.order manager,model_sale_custom_order,sale_custom.group_sale_custom_manager,1,1,1,1
+```
+
+### Column reference
+
+| Column | Value Pattern | Notes |
+|---|---|---|
+| `id` | `access_<model_underscore>_<group>` | Must be unique |
+| `name` | `<module>.<model> <group>` | Human-readable only |
+| `model_id:id` | `model_<model_dots_as_underscores>` | `sale.order` → `model_sale_order` |
+| `group_id:id` | `<module>.group_<module>_<role>` | Module prefix is required |
+| `perm_*` | `1` or `0` | Integer — never `True`/`False` |
+
+---
+
+## `res.groups` XML Pattern
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <!-- Module category — appears as section in Settings > Users & Companies > Groups -->
+        <record id="module_category_sale_custom" model="ir.module.category">
+            <field name="name">Sale Custom</field>
+            <field name="sequence">10</field>
+        </record>
+
+        <!-- User group — read-only access -->
+        <record id="group_sale_custom_user" model="res.groups">
+            <field name="name">User</field>
+            <field name="category_id" ref="module_category_sale_custom"/>
+        </record>
+
+        <!-- Manager group — full access, automatically includes User permissions -->
+        <record id="group_sale_custom_manager" model="res.groups">
+            <field name="name">Manager</field>
+            <field name="category_id" ref="module_category_sale_custom"/>
+            <field name="implied_ids" eval="[(4, ref('group_sale_custom_user'))]"/>
+        </record>
+
+    </data>
+</odoo>
+```
+
+---
+
+## `ir.rule` Pattern
+
+### Own-records rule (v17/v18)
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <!-- User sees only records assigned to themselves -->
+        <record id="rule_sale_custom_order_own" model="ir.rule">
+            <field name="name">Sale Custom Order: Own Records</field>
+            <field name="model_id" ref="model_sale_custom_order"/>
+            <field name="domain_force">[('user_id', '=', user.id)]</field>
+            <field name="groups" eval="[(4, ref('sale_custom.group_sale_custom_user'))]"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_unlink" eval="True"/>
+        </record>
+
+    </data>
+</odoo>
+```
+
+### v16 vs v17+ — global rule
+
+```xml
+<!-- ✅ v16 — explicit global field -->
+<record id="rule_global_v16" model="ir.rule">
+    <field name="name">My Model: All Records (v16)</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="domain_force">[(1, '=', 1)]</field>
+    <field name="global" eval="True"/>
+</record>
+
+<!-- ✅ v17/v18 — global = no groups (omit the groups field entirely) -->
+<record id="rule_global_v17" model="ir.rule">
+    <field name="name">My Model: All Records (v17+)</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="domain_force">[(1, '=', 1)]</field>
+    <!-- No groups field → automatically global -->
+</record>
+```
+
+### Multi-company isolation rule
+
+```xml
+<record id="rule_my_model_company" model="ir.rule">
+    <field name="name">My Model: Multi-Company</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+    <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+    <field name="perm_read" eval="True"/>
+    <field name="perm_write" eval="True"/>
+    <field name="perm_create" eval="True"/>
+    <field name="perm_unlink" eval="False"/>
+</record>
+```
+
+### Available context variables in `domain_force`
+
+| Variable | Type | Description |
+|---|---|---|
+| `user` | `res.users` recordset | Current logged-in user |
+| `time` | Python `time` module | For date-based conditions |
+| `company_ids` | `list[int]` | IDs of user's allowed companies |
+
+---
+
+## Assets
+
+| File | Use Case |
+|---|---|
+| [`assets/access-template.csv`](assets/access-template.csv) | Drop-in `ir.model.access.csv` with two-tier permissions |
+| [`assets/groups-template.xml`](assets/groups-template.xml) | Module category + User/Manager group definitions |
+| [`assets/record-rule-template.xml`](assets/record-rule-template.xml) | Own-records rule + multi-company rule (v17+ syntax) |
+
+---
+
+## Common Mistakes
+
+### 1. [v16→v17] Using `global` field on `ir.rule`
+
+```xml
+<!-- ❌ WRONG in v17+ — field does not exist -->
+<field name="global" eval="True"/>
+
+<!-- ✅ CORRECT — just omit the groups field -->
+```
+
+The `global` field was removed in v17. A rule with an empty `groups` m2m is automatically global.
+
+---
+
+### 2. Wrong CSV column order
+
+```csv
+# ❌ WRONG — missing perm_unlink column (silent load failure)
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create
+access_my_model_user,my.model user,model_my_model,my_module.group_user,1,0,0
+
+# ✅ CORRECT — all 8 columns in exact order
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_my_model_user,my.model user,model_my_model,my_module.group_user,1,0,0,0
+```
+
+A shifted or missing column causes a **silent load failure** — no error is raised, but permissions are wrong.
+
+---
+
+### 3. Missing module prefix on `group_id:id`
+
+```csv
+# ❌ WRONG — Odoo cannot resolve the group XML ID without module prefix
+access_my_model_user,my.model user,model_my_model,group_my_module_user,1,0,0,0
+
+# ✅ CORRECT — always include the module name
+access_my_model_user,my.model user,model_my_model,my_module.group_my_module_user,1,0,0,0
+```
+
+---
+
+### 4. Loading CSV before groups in the manifest
+
+```python
+# ❌ WRONG — CSV references groups that haven't been created yet
+'data': [
+    'security/ir.model.access.csv',
+    'security/groups.xml',
+]
+
+# ✅ CORRECT — groups.xml must load first
+'data': [
+    'security/groups.xml',
+    'security/ir.model.access.csv',
+]
+```
+
+This raises a `ManyToMany` foreign key constraint error at module install time.
+
+---
+
+### 5. Omitting `noupdate="1"` on record rules
+
+```xml
+<!-- ❌ WRONG — rule is reset to default on every --update -->
+<odoo>
+    <data>
+        <record id="rule_my_model_own" model="ir.rule">...</record>
+    </data>
+</odoo>
+
+<!-- ✅ CORRECT — preserves admin customizations made via Settings UI -->
+<odoo>
+    <data noupdate="1">
+        <record id="rule_my_model_own" model="ir.rule">...</record>
+    </data>
+</odoo>
+```
+
+---
+
+### 6. Using `True`/`False` strings in CSV instead of integers
+
+```csv
+# ❌ WRONG — string booleans are not valid
+access_my_model_user,my.model user,model_my_model,my_module.group_user,True,False,False,False
+
+# ✅ CORRECT — integers only
+access_my_model_user,my.model user,model_my_model,my_module.group_user,1,0,0,0
+```
+
+---
+
+### 7. Confusing ACL with record rules
+
+- **`ir.model.access.csv`** controls whether a user can access the model at all (table-level gate).
+- **`ir.rule`** controls which rows the user can see or edit (row-level filter).
+
+Setting up ACL without record rules means all users with access see **all rows**. Both layers are needed for proper data isolation (e.g., each salesperson sees only their own orders).
+
+---
+
+## References
+
+| Resource | Description |
+|---|---|
+| [`references/security-attributes.md`](references/security-attributes.md) | Full compatibility table v16/v17/v18, CSV column reference, base groups |
+| [Odoo Security Documentation](https://www.odoo.com/documentation/17.0/developer/reference/backend/security.html) | Official access rights and record rules reference |

--- a/skills/odoo-security/assets/access-template.csv
+++ b/skills/odoo-security/assets/access-template.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_<model_name>_user,<module_name>.<model_name> user,model_<model_name>,<module_name>.group_<module_name>_user,1,0,0,0
+access_<model_name>_manager,<module_name>.<model_name> manager,model_<model_name>,<module_name>.group_<module_name>_manager,1,1,1,1

--- a/skills/odoo-security/assets/groups-template.xml
+++ b/skills/odoo-security/assets/groups-template.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <!-- Module category (appears as section in Settings > Users & Companies > Groups) -->
+        <record id="module_category_<module_name>" model="ir.module.category">
+            <field name="name"><Module Display Name></field>
+            <field name="sequence">10</field>
+        </record>
+
+        <!-- Base user group — read-only access -->
+        <record id="group_<module_name>_user" model="res.groups">
+            <field name="name">User</field>
+            <field name="category_id" ref="module_category_<module_name>"/>
+        </record>
+
+        <!-- Manager group — full access, implies User -->
+        <record id="group_<module_name>_manager" model="res.groups">
+            <field name="name">Manager</field>
+            <field name="category_id" ref="module_category_<module_name>"/>
+            <field name="implied_ids" eval="[(4, ref('group_<module_name>_user'))]"/>
+        </record>
+
+    </data>
+</odoo>

--- a/skills/odoo-security/assets/record-rule-template.xml
+++ b/skills/odoo-security/assets/record-rule-template.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <!--
+        noupdate="1" is required for record rules.
+        It prevents rules from being overwritten on --update,
+        preserving any UI customizations made by administrators.
+    -->
+    <data noupdate="1">
+
+        <!-- ✅ v17/v18 — "Own records only" rule (user sees only their own records) -->
+        <record id="rule_<model_name>_own_records" model="ir.rule">
+            <field name="name"><Model Name>: Own Records</field>
+            <field name="model_id" ref="model_<model_name>"/>
+            <field name="domain_force">[('user_id', '=', user.id)]</field>
+            <field name="groups" eval="[(4, ref('<module_name>.group_<module_name>_user'))]"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_unlink" eval="True"/>
+        </record>
+
+        <!--
+            ❌ v16 only — global field was REMOVED in v17.
+            In v17+, a rule with no groups is automatically global.
+
+        <record id="rule_<model_name>_global_example" model="ir.rule">
+            <field name="name"><Model Name>: Global Rule (v16 only)</field>
+            <field name="model_id" ref="model_<model_name>"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="global" eval="True"/>
+        </record>
+        -->
+
+        <!-- ✅ v16/v17/v18 — Multi-company isolation rule -->
+        <record id="rule_<model_name>_company" model="ir.rule">
+            <field name="name"><Model Name>: Multi-Company</field>
+            <field name="model_id" ref="model_<model_name>"/>
+            <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+
+    </data>
+</odoo>

--- a/skills/odoo-security/references/security-attributes.md
+++ b/skills/odoo-security/references/security-attributes.md
@@ -1,0 +1,82 @@
+# Security Attributes — Version Compatibility Reference
+
+## `ir.rule` Field Compatibility
+
+| Field / Behavior | v16 | v17 | v18 | Notes |
+|---|---|---|---|---|
+| `global` field | ✅ Valid | ❌ Removed | ❌ Removed | Rule is global when `groups` m2m is empty |
+| `domain_force` | ✅ | ✅ | ✅ | Odoo domain string |
+| `perm_read/write/create/unlink` | ✅ | ✅ | ✅ | Boolean attributes |
+| `groups` (m2m) | ✅ | ✅ | ✅ | Empty = global in v17+ |
+| `noupdate="1"` wrapper | Recommended | Recommended | Recommended | Prevents overwrite on `--update` |
+| Context var `user` | ✅ | ✅ | ✅ | Current user recordset |
+| Context var `time` | ✅ | ✅ | ✅ | Python `time` module |
+| Context var `company_ids` | ✅ | ✅ | ✅ | List of allowed company IDs |
+
+## `ir.model.access.csv` Column Reference
+
+Columns must appear in **exactly this order**:
+
+| Position | Column | Example | Notes |
+|---|---|---|---|
+| 1 | `id` | `access_sale_order_user` | External ID, unique per row |
+| 2 | `name` | `sale.order user` | Human-readable label |
+| 3 | `model_id:id` | `model_sale_order` | Dots → underscores, `model_` prefix |
+| 4 | `group_id:id` | `sales.group_sales_user` | Module prefix required. Leave blank = all users |
+| 5 | `perm_read` | `1` | Integer `1` or `0` only, never `True` |
+| 6 | `perm_write` | `0` | Integer `1` or `0` only |
+| 7 | `perm_create` | `0` | Integer `1` or `0` only |
+| 8 | `perm_unlink` | `0` | Integer `1` or `0` only |
+
+## `res.groups` Field Compatibility
+
+| Field | v16 | v17 | v18 | Notes |
+|---|---|---|---|---|
+| `name` | ✅ | ✅ | ✅ | Displayed in Settings UI |
+| `category_id` | ✅ | ✅ | ✅ | Controls section in Settings > Groups |
+| `implied_ids` | ✅ | ✅ | ✅ | `eval="[(4, ref('...'))]"` to add |
+| `users` | ✅ | ✅ | ✅ | m2m to `res.users` |
+| `comment` | ✅ | ✅ | ✅ | Optional description |
+
+## Standard Base Groups
+
+| XML ID | Description | Use When |
+|---|---|---|
+| `base.group_user` | Internal user | All internal users |
+| `base.group_portal` | Portal user | External/customer portal access |
+| `base.group_public` | Public | Unauthenticated/anonymous |
+| `base.group_system` | Settings (Technical) | Admin-level configuration access |
+| `base.group_erp_manager` | ERP Manager | Cross-app administrative access |
+
+## v16 → v17 Migration: `ir.rule global` Field
+
+### v16 (valid)
+```xml
+<record id="rule_all_records" model="ir.rule">
+    <field name="name">My Model: All Records</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="domain_force">[(1, '=', 1)]</field>
+    <field name="global" eval="True"/>
+</record>
+```
+
+### v17/v18 equivalent (global = no groups)
+```xml
+<record id="rule_all_records" model="ir.rule">
+    <field name="name">My Model: All Records</field>
+    <field name="model_id" ref="model_my_model"/>
+    <field name="domain_force">[(1, '=', 1)]</field>
+    <!-- No <field name="groups"> → automatically global in v17+ -->
+</record>
+```
+
+## `__manifest__.py` — Security File Load Order
+
+```python
+'data': [
+    'security/groups.xml',          # 1. Groups first — CSV references them
+    'security/ir.model.access.csv', # 2. ACL second — references groups
+    'security/ir_rule.xml',         # 3. Record rules — references models and groups
+    'views/my_model_views.xml',     # 4. Views last
+],
+```


### PR DESCRIPTION
### Context

Implements the `odoo-security` skill — Tier 1 item #5 in the roadmap. Covers all security artifacts needed for an Odoo module: ACL, record rules, and groups.

### Description

- Add `skills/odoo-security/SKILL.md` with patterns for `ir.model.access.csv`, `ir.rule`, and `res.groups`
- Add `assets/access-template.csv` — drop-in two-tier ACL template
- Add `assets/groups-template.xml` — module category + User/Manager group definitions
- Add `assets/record-rule-template.xml` — own-records + multi-company rules (v17+ syntax)
- Add `references/security-attributes.md` — full compatibility table v16/v17/v18

- **Module**: `odoo-security` skill
- **Odoo Version**: v16, v17, v18
- **Breaking Change**: No

### Odoo Version Compatibility

- [x] Tested on Odoo v16
- [x] Tested on Odoo v17
- [x] Tested on Odoo v18

### Steps to Review

1. Load skill in an Odoo project context
2. Verify ACL template has correct 8-column order
3. Verify record rule uses `noupdate="1"`
4. Verify v17+ drops the `global` field

### Checklist

- [x] No deprecated API used
- [x] OCA naming conventions followed
- [x] `AGENTS.md` updated with `odoo-security` entry

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the applicable module license (LGPL-3 or AGPL-3).