### PR TITLE
feat(tests): add odoo-testing skill with TDD workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Use these skills for detailed patterns on-demand:
 | `odoo-orm`      | Models, fields, decorators, recordsets, CRUD    | [SKILL.md](skills/odoo-orm/SKILL.md)      |
 | `odoo-views`    | Form, list, search, kanban views (v16/v17/v18)  | [SKILL.md](skills/odoo-views/SKILL.md)    |
 | `odoo-security` | ir.model.access.csv, ir.rule, res.groups        | [SKILL.md](skills/odoo-security/SKILL.md) |
+| `odoo-testing`  | TDD workflow: TransactionCase, HttpCase, @tagged | [SKILL.md](skills/odoo-testing/SKILL.md) |
 | `odoo-oca`      | OCA conventions: naming, versioning, manifest   | [SKILL.md](skills/odoo-oca/SKILL.md)      |
 
 ### DevOps & Workflow Skills

--- a/skills/odoo-testing/SKILL.md
+++ b/skills/odoo-testing/SKILL.md
@@ -1,0 +1,402 @@
+---
+name: odoo-testing
+description: >
+  Test-Driven Development workflow for Odoo modules (v16/v17/v18).
+  Covers TransactionCase, HttpCase, @tagged, common.py, and the full
+  Red → Green → Refactor cycle. MANDATORY when implementing features or fixing bugs.
+license: MIT
+metadata:
+  author: Geraldow
+  version: "1.0.0"
+  supported_versions: ["16", "17", "18"]
+  skill_id: ODSK-SKL-TEST
+auto_invoke:
+  - "Writing Odoo tests"
+  - "Implementing a new Odoo feature"
+  - "Fixing a bug in an Odoo module"
+  - "Refactoring Odoo model or controller"
+  - "Creating tests/ folder in Odoo module"
+---
+
+# odoo-testing
+
+## TDD Cycle (MANDATORY)
+
+```text
++-------------------------------------------+
+|  RED -> GREEN -> REFACTOR                 |
+|     ^                        |            |
+|     +------------------------+            |
++-------------------------------------------+
+```
+
+**The question is NOT "should I write tests?" but "what tests do I need?"**
+
+---
+
+## The Three Laws of TDD
+
+1. **No production code** until you have a failing test
+2. **No more test** than necessary to fail
+3. **No more code** than necessary to pass
+
+---
+
+## Detect Your Test Type
+
+Before starting, identify what you are testing:
+
+| Scenario | Test Class | File pattern | When to use |
+|---|---|---|---|
+| Business logic, ORM, compute | `TransactionCase` | `tests/test_*.py` | Models, fields, methods |
+| HTTP routes, JSON-RPC, wizards | `HttpCase` | `tests/test_*.py` | Controllers, tours |
+| Both at once | `TransactionCase` + `HttpCase` | separate files | Keep them split |
+
+### Module structure
+
+```text
+my_module/
+├── __manifest__.py
+└── tests/
+    ├── __init__.py        ← import all test files
+    ├── common.py          ← shared setUp (base class)
+    ├── test_my_model.py   ← TransactionCase tests
+    └── test_controllers.py ← HttpCase tests
+```
+
+---
+
+## Phase 0: Assessment (ALWAYS FIRST)
+
+Before writing any code:
+
+```bash
+# 1. Find existing tests
+find my_module/tests/ -name "test_*.py"
+
+# 2. Run existing tests for the module
+python odoo-bin -c odoo.conf -d mydb --test-enable --stop-after-init -i my_module
+
+# 3. Run with tag filter
+python odoo-bin -c odoo.conf -d mydb --test-enable --stop-after-init --test-tags my_module
+
+# 4. Read existing tests — understand patterns already in use
+```
+
+### Decision Tree
+
+```text
++------------------------------------------+
+|    Does test file exist for this code?   |
++----------+-----------------------+--------+
+           | NO                    | YES
+           v                       v
++------------------+    +------------------+
+| CREATE test file |    | Check coverage   |
+| -> Phase 1: RED  |    | for your change  |
++------------------+    +--------+---------+
+                                  |
+                         +--------+--------+
+                         | Missing cases?  |
+                         +---+---------+---+
+                             | YES     | NO
+                             v         v
+                     +-----------+ +-----------+
+                     | ADD tests | | Proceed   |
+                     | Phase 1   | | Phase 2   |
+                     +-----------+ +-----------+
+```
+
+---
+
+## Phase 1: RED — Write Failing Tests
+
+### `common.py` — Shared base class
+
+```python
+from odoo.tests.common import TransactionCase
+
+
+class TestSaleCustomBase(TransactionCase):
+    """Shared setUp for all sale_custom tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
+        cls.product = cls.env["product.product"].create({
+            "name": "Test Product",
+            "list_price": 100.0,
+        })
+```
+
+### `TransactionCase` test (business logic)
+
+```python
+from .common import TestSaleCustomBase
+from odoo.tests.common import tagged
+
+
+@tagged("post_install", "-at_install", "sale_custom")
+class TestSaleCustomOrder(TestSaleCustomBase):
+
+    def test_order_total_with_discount(self):
+        # Given
+        order = self.env["sale.order"].create({
+            "partner_id": self.partner.id,
+        })
+        self.env["sale.order.line"].create({
+            "order_id": order.id,
+            "product_id": self.product.id,
+            "product_uom_qty": 2,
+            "discount": 10.0,
+        })
+
+        # When
+        order.action_confirm()
+
+        # Then
+        self.assertAlmostEqual(order.amount_total, 180.0)  # 200 - 10%
+```
+
+**Run → MUST fail:** references code that doesn't exist yet.
+
+### `HttpCase` test (controllers / tours)
+
+```python
+from odoo.tests.common import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSaleCustomController(HttpCase):
+
+    def test_sale_custom_tour(self):
+        self.start_tour(
+            "/web",
+            "sale_custom_tour",
+            login="admin",
+        )
+```
+
+### For BUG FIXES
+
+Write a test that **reproduces the bug** first:
+
+```python
+def test_discount_not_applied_on_zero_qty(self):
+    # Reproduces bug: discount applied even when qty = 0
+    line = self.env["sale.order.line"].create({
+        "order_id": self.order.id,
+        "product_id": self.product.id,
+        "product_uom_qty": 0,
+        "discount": 10.0,
+    })
+    # Then — should be 0, currently returns wrong value
+    self.assertEqual(line.price_subtotal, 0.0)
+```
+
+**Run → Should FAIL (reproducing the bug)**
+
+### For REFACTORING
+
+Capture ALL current behavior BEFORE refactoring:
+
+```bash
+# Run ALL existing tests — they should PASS
+# This is your safety net
+python odoo-bin -c odoo.conf -d mydb --test-enable --stop-after-init --test-tags my_module
+```
+
+---
+
+## Phase 2: GREEN — Minimum Code
+
+Write the MINIMUM code to make the test pass. Hardcoding is valid for the first test.
+
+```python
+# Test expects amount_total == 180.0
+def action_confirm(self):
+    self.amount_total = 180.0  # FAKE IT — hardcoded is valid for first test
+    self.state = "sale"
+```
+
+**This passes. But we're not done...**
+
+---
+
+## Phase 3: Triangulation (CRITICAL)
+
+**One test allows faking. Multiple tests FORCE real logic.**
+
+Add tests with different inputs that break the hardcoded value:
+
+| Scenario | Required? |
+|---|---|
+| Happy path | YES |
+| Zero quantity / empty order | YES |
+| Boundary values (100% discount) | YES |
+| Different discount rates | YES — breaks the fake |
+| Error / invalid state | YES |
+
+```python
+def test_order_total_no_discount(self):
+    # Different input -> breaks hardcoded 180.0
+    line = self.env["sale.order.line"].create({
+        "order_id": self.order.id,
+        "product_id": self.product.id,
+        "product_uom_qty": 1,
+        "discount": 0.0,
+    })
+    self.order.action_confirm()
+    self.assertAlmostEqual(self.order.amount_total, 100.0)  # No discount
+
+def test_order_total_full_discount(self):
+    line = self.env["sale.order.line"].create({
+        "order_id": self.order.id,
+        "product_id": self.product.id,
+        "product_uom_qty": 1,
+        "discount": 100.0,
+    })
+    self.order.action_confirm()
+    self.assertAlmostEqual(self.order.amount_total, 0.0)  # Full discount
+```
+
+**Now the fake BREAKS → Real implementation required.**
+
+---
+
+## Phase 4: REFACTOR
+
+Tests GREEN → Improve code quality WITHOUT changing behavior.
+
+- Extract helper methods to `common.py`
+- Rename test methods to be descriptive
+- Remove duplication in `setUpClass`
+- Add `@tagged` to all test classes for selective runs
+
+**Run tests after EACH change → Must stay GREEN**
+
+---
+
+## `@tagged` Reference
+
+```python
+from odoo.tests.common import tagged
+
+# Standard tags:
+@tagged("post_install", "-at_install")  # Run after install, not during
+@tagged("at_install")                   # Run during install only
+@tagged("standard")                     # Default Odoo tag (always runs)
+@tagged("-standard", "my_module")       # Skip standard, only run with my_module tag
+```
+
+| Tag | Meaning |
+|---|---|
+| `post_install` | Runs after all modules are installed |
+| `at_install` | Runs while the module is being installed |
+| `-at_install` | Exclude from install-time runs (prefix `-` negates) |
+| `standard` | Included in default test suite |
+| `my_module` | Custom tag — use for selective CI runs |
+
+---
+
+## Quick Reference
+
+```text
++--------------------------------------------------+
+|                  TDD WORKFLOW (Odoo)             |
++--------------------------------------------------+
+| 0. ASSESS: What tests exist? What's missing?    |
+|                                                  |
+| 1. RED: Write ONE failing test                  |
+|    +-- TransactionCase or HttpCase?             |
+|    +-- Run → Must fail                          |
+|                                                  |
+| 2. GREEN: Write MINIMUM code to pass            |
+|    +-- Fake It is valid for the first test      |
+|                                                  |
+| 3. TRIANGULATE: Add tests that break the fake   |
+|    +-- Different inputs, edge cases             |
+|                                                  |
+| 4. REFACTOR: Improve with confidence            |
+|    +-- Tests stay green throughout              |
+|                                                  |
+| 5. REPEAT: Next behavior/requirement            |
++--------------------------------------------------+
+```
+
+---
+
+## Anti-Patterns (NEVER DO)
+
+```python
+# 1. Code first, tests after
+def new_feature(self): ...  # Then writing tests = USELESS
+
+# 2. Skip triangulation
+# Single test allows faking forever
+
+# 3. Test implementation details
+self.assertEqual(mock_method.call_count, 3)  # BAD — brittle coupling
+
+# 4. Use self.env.cr.execute() in tests to inspect DB state
+# BAD — use ORM assertions instead
+
+# 5. All tests at once before any code
+# Write ONE test, make it pass, THEN write the next
+
+# 6. Giant test methods
+# Each test should verify ONE behavior
+
+# 7. Depending on external data (production DB, demo data)
+# BAD — always create your own records in setUpClass or test method
+```
+
+---
+
+## Commands
+
+```bash
+# Run all tests for a module
+python odoo-bin -c odoo.conf -d mydb \
+  --test-enable --stop-after-init -i my_module
+
+# Run only tests tagged with a custom tag
+python odoo-bin -c odoo.conf -d mydb \
+  --test-enable --stop-after-init \
+  --test-tags my_module
+
+# Run a specific test file
+python odoo-bin -c odoo.conf -d mydb \
+  --test-enable --stop-after-init \
+  --test-tags /my_module/tests/test_my_model.py
+
+# Run a specific test method
+python odoo-bin -c odoo.conf -d mydb \
+  --test-enable --stop-after-init \
+  --test-tags /my_module/tests/test_my_model.py:TestMyModel.test_method_name
+
+# Run post_install tests only (skip at_install)
+python odoo-bin -c odoo.conf -d mydb \
+  --test-enable --stop-after-init \
+  --test-tags post_install,-at_install
+```
+
+---
+
+## Assets
+
+| File | Use Case |
+|---|---|
+| [`assets/common-template.py`](assets/common-template.py) | Base class with shared `setUpClass` |
+| [`assets/transaction-case-template.py`](assets/transaction-case-template.py) | TransactionCase test file template |
+| [`assets/http-case-template.py`](assets/http-case-template.py) | HttpCase / tour test template |
+
+---
+
+## References
+
+| Resource | Description |
+|---|---|
+| [`references/testing-patterns.md`](references/testing-patterns.md) | Assert methods, mock patterns, v16/v17/v18 compatibility |
+| [Odoo Testing Documentation](https://www.odoo.com/documentation/17.0/developer/reference/backend/testing.html) | Official testing reference |

--- a/skills/odoo-testing/assets/common-template.py
+++ b/skills/odoo-testing/assets/common-template.py
@@ -1,0 +1,49 @@
+"""
+common.py — Shared base class for all tests in this module.
+
+Usage:
+    from .common import TestMyModuleBase
+
+    class TestMyModel(TestMyModuleBase):
+        def test_something(self):
+            ...
+
+Replace `my_module` with your actual module name throughout.
+"""
+from odoo.tests.common import TransactionCase
+
+
+class TestMyModuleBase(TransactionCase):
+    """
+    Base class shared by all TransactionCase tests in my_module.
+
+    Create here:
+    - Records that every test will need (partner, product, company, etc.)
+    - Utility methods reused across multiple test files
+
+    Keep this class LEAN — only create records that 3+ tests actually need.
+    Test-specific setup belongs in the test method itself.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # --- Partners ---
+        cls.partner = cls.env["res.partner"].create({
+            "name": "Test Partner",
+            "email": "test@example.com",
+        })
+
+        # --- Products ---
+        cls.product = cls.env["product.product"].create({
+            "name": "Test Product",
+            "list_price": 100.0,
+            "type": "service",
+        })
+
+        # --- Users (optional — only if your tests need specific users) ---
+        # cls.user_demo = cls.env.ref("base.user_demo")
+
+        # --- Companies (optional — only for multi-company tests) ---
+        # cls.company_2 = cls.env["res.company"].create({"name": "Company B"})

--- a/skills/odoo-testing/assets/http-case-template.py
+++ b/skills/odoo-testing/assets/http-case-template.py
@@ -1,0 +1,79 @@
+"""
+test_controllers.py — HttpCase tests for JSON-RPC controllers and JS tours.
+
+Use this template for:
+- HTTP routes that return JSON
+- JSON-RPC endpoint calls
+- JavaScript UI tours (end-to-end via browser)
+- Wizard HTTP flows
+
+Replace `my_module`, `my_tour_name` with your actual names.
+"""
+from odoo.tests.common import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install", "my_module")
+class TestMyModuleControllers(HttpCase):
+    """HTTP and tour tests for my_module."""
+
+    # -------------------------------------------------------------------------
+    # JSON-RPC endpoint test
+    # -------------------------------------------------------------------------
+
+    def test_my_json_rpc_endpoint_returns_expected_data(self):
+        """Call a JSON-RPC route and assert the response shape."""
+        self.authenticate("admin", "admin")
+
+        response = self.url_open(
+            "/web/dataset/call_kw",
+            data={
+                "jsonrpc": "2.0",
+                "method": "call",
+                "id": 1,
+                "params": {
+                    "model": "my.model",
+                    "method": "my_method",
+                    "args": [],
+                    "kwargs": {},
+                },
+            },
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertIn("result", result)
+
+    # -------------------------------------------------------------------------
+    # JavaScript tour test
+    # -------------------------------------------------------------------------
+
+    def test_my_module_tour(self):
+        """
+        Run the `my_module_tour` JS tour as admin.
+
+        The tour must be defined in:
+            my_module/static/src/js/tours/my_module_tour.js
+        and registered via:
+            odoo.define('my_module.tour', ...)
+        """
+        self.start_tour(
+            "/web",
+            "my_module_tour",
+            login="admin",
+        )
+
+    # -------------------------------------------------------------------------
+    # Portal / public route test
+    # -------------------------------------------------------------------------
+
+    def test_public_route_returns_200(self):
+        """Test a route accessible without authentication."""
+        response = self.url_open("/my_module/public-page")
+        self.assertEqual(response.status_code, 200)
+
+    def test_authenticated_route_requires_login(self):
+        """Test that a protected route redirects unauthenticated users."""
+        response = self.url_open("/my_module/private-page", allow_redirects=False)
+        # Expect redirect to /web/login
+        self.assertIn(response.status_code, [301, 302, 303])

--- a/skills/odoo-testing/assets/transaction-case-template.py
+++ b/skills/odoo-testing/assets/transaction-case-template.py
@@ -1,0 +1,105 @@
+"""
+test_my_model.py — TransactionCase tests for business logic, ORM, compute fields.
+
+Use this template for:
+- Model methods and computed fields
+- ORM creates, writes, unlinks
+- Onchanges and constrains
+- Workflow state transitions
+
+Replace `my_module`, `MyModel`, `my.model` with your actual names.
+"""
+from odoo.tests.common import tagged
+
+from .common import TestMyModuleBase
+
+
+@tagged("post_install", "-at_install", "my_module")
+class TestMyModel(TestMyModuleBase):
+    """Tests for my.model business logic."""
+
+    # -------------------------------------------------------------------------
+    # Happy path
+    # -------------------------------------------------------------------------
+
+    def test_create_record_with_valid_data(self):
+        # Given
+        vals = {
+            "name": "Test Record",
+            "partner_id": self.partner.id,
+        }
+
+        # When
+        record = self.env["my.model"].create(vals)
+
+        # Then
+        self.assertEqual(record.name, "Test Record")
+        self.assertEqual(record.partner_id, self.partner)
+
+    # -------------------------------------------------------------------------
+    # Computed fields
+    # -------------------------------------------------------------------------
+
+    def test_computed_field_returns_expected_value(self):
+        # Given
+        record = self.env["my.model"].create({
+            "name": "Computed Test",
+            "partner_id": self.partner.id,
+            # set fields that the computed field depends on
+        })
+
+        # When — trigger recompute if needed
+        record._compute_my_field()
+
+        # Then
+        self.assertEqual(record.my_computed_field, "expected_value")
+
+    # -------------------------------------------------------------------------
+    # State transitions / workflows
+    # -------------------------------------------------------------------------
+
+    def test_confirm_moves_state_to_confirmed(self):
+        # Given
+        record = self.env["my.model"].create({
+            "name": "State Test",
+            "partner_id": self.partner.id,
+        })
+        self.assertEqual(record.state, "draft")
+
+        # When
+        record.action_confirm()
+
+        # Then
+        self.assertEqual(record.state, "confirmed")
+
+    # -------------------------------------------------------------------------
+    # Edge cases / triangulation
+    # -------------------------------------------------------------------------
+
+    def test_zero_quantity_produces_zero_total(self):
+        # Given — boundary: qty = 0
+        record = self.env["my.model"].create({
+            "name": "Zero Test",
+            "partner_id": self.partner.id,
+            "quantity": 0,
+        })
+
+        # When
+        record.action_confirm()
+
+        # Then
+        self.assertAlmostEqual(record.amount_total, 0.0)
+
+    # -------------------------------------------------------------------------
+    # Constraints / validation errors
+    # -------------------------------------------------------------------------
+
+    def test_negative_quantity_raises_validation_error(self):
+        from odoo.exceptions import ValidationError
+
+        with self.assertRaises(ValidationError):
+            self.env["my.model"].create({
+                "name": "Invalid",
+                "partner_id": self.partner.id,
+                "quantity": -1,
+            })

--- a/skills/odoo-testing/references/testing-patterns.md
+++ b/skills/odoo-testing/references/testing-patterns.md
@@ -1,0 +1,186 @@
+# Odoo Testing Patterns Reference
+
+## Assert Methods (TransactionCase)
+
+| Assert | Use for |
+|--------|---------|
+| `self.assertEqual(a, b)` | Exact equality (IDs, strings, states) |
+| `self.assertAlmostEqual(a, b)` | Float comparisons (monetary amounts) |
+| `self.assertTrue(expr)` / `self.assertFalse(expr)` | Boolean conditions |
+| `self.assertIn(item, container)` | Membership check (recordsets, lists) |
+| `self.assertNotIn(item, container)` | Absence check |
+| `self.assertRaises(ExceptionClass)` | Expect an exception |
+| `self.assertRecordValues(records, expected)` | Compare multiple recordset fields at once |
+
+### `assertRecordValues` example
+
+```python
+self.assertRecordValues(order.order_line, [
+    {"product_id": self.product.id, "product_uom_qty": 2.0, "price_unit": 100.0},
+    {"product_id": self.product_b.id, "product_uom_qty": 1.0, "price_unit": 50.0},
+])
+```
+
+---
+
+## Exception Assertions
+
+```python
+from odoo.exceptions import ValidationError, UserError, AccessError
+
+# Expect a ValidationError
+with self.assertRaises(ValidationError):
+    record.write({"quantity": -1})
+
+# Expect a UserError
+with self.assertRaises(UserError):
+    record.action_confirm()
+
+# Expect AccessError (permissions)
+with self.assertRaises(AccessError):
+    record.with_user(self.user_no_access).unlink()
+```
+
+---
+
+## Switching User Context
+
+```python
+# Run as a specific user
+record_as_user = self.env["my.model"].with_user(self.user_demo)
+
+# Run as superuser (bypass all access rules — use sparingly in tests)
+record_as_admin = self.env["my.model"].sudo()
+
+# Switch company context
+record_company_b = self.env["my.model"].with_company(self.company_2)
+```
+
+---
+
+## Mocking External Calls
+
+Use `unittest.mock.patch` for:
+- External API calls (payment providers, shipping, email)
+- Date/time (freeze time for compute tests)
+- Services that can't run in test environment
+
+```python
+from unittest.mock import patch
+
+def test_payment_provider_called(self):
+    with patch("odoo.addons.my_module.models.my_model.requests.post") as mock_post:
+        mock_post.return_value.json.return_value = {"status": "ok"}
+
+        result = self.record.send_to_provider()
+
+        mock_post.assert_called_once()
+        self.assertEqual(result, "ok")
+```
+
+---
+
+## Freezing Date/Time
+
+```python
+from unittest.mock import patch
+from datetime import date
+
+def test_date_based_compute(self):
+    with patch("odoo.fields.Date.today", return_value=date(2025, 1, 15)):
+        self.record._compute_deadline()
+        self.assertEqual(self.record.deadline, date(2025, 1, 30))
+```
+
+---
+
+## v16 / v17 / v18 Compatibility
+
+| Feature | v16 | v17 | v18 |
+|---------|-----|-----|-----|
+| `assertRecordValues` | ✅ | ✅ | ✅ |
+| `HttpCase.url_open` | ✅ | ✅ | ✅ |
+| `HttpCase.authenticate` | ✅ | ✅ | ✅ |
+| `@tagged` decorator | ✅ | ✅ | ✅ |
+| `ir.rule` `global` field | ✅ | ❌ removed | ❌ removed |
+| `name_get()` override | ✅ | ⚠️ deprecated | ❌ use `_rec_name` |
+| `_name_search()` | ✅ | ✅ | ✅ |
+
+---
+
+## Test Isolation Rules
+
+1. **Never depend on demo data** — always create your own records in `setUpClass` or the test method.
+2. **Never use `self.env.cr.execute()`** in tests to inspect DB state — use ORM assertions.
+3. **Each test is rolled back** after execution — state does not leak between tests in `TransactionCase`.
+4. **`setUpClass` runs once per class** — records created there are shared (read-only pattern recommended).
+5. **`setUp` runs before each test** — use for state that must be fresh per test.
+
+---
+
+## Common Pitfalls
+
+### Pitfall: Testing with wrong user
+```python
+# BAD — testing with admin bypasses real access rules
+self.env["my.model"].sudo().create(...)
+
+# GOOD — test with the actual user role you're validating
+self.env["my.model"].with_user(self.user_salesperson).create(...)
+```
+
+### Pitfall: Using `assertEqual` for floats
+```python
+# BAD — floating point comparison may fail
+self.assertEqual(order.amount_total, 180.0)
+
+# GOOD — use assertAlmostEqual for monetary values
+self.assertAlmostEqual(order.amount_total, 180.0)
+```
+
+### Pitfall: Missing `__init__.py` import
+```python
+# tests/__init__.py must import all test files
+from . import test_my_model, test_controllers  # Add new files here
+```
+
+### Pitfall: Running tests without --test-enable
+```bash
+# WRONG — tests won't run
+python odoo-bin -c odoo.conf -d mydb -i my_module
+
+# CORRECT
+python odoo-bin -c odoo.conf -d mydb --test-enable --stop-after-init -i my_module
+```
+
+---
+
+## `__init__.py` Pattern
+
+```python
+# tests/__init__.py
+from . import common          # NOT a test file, but must be importable
+from . import test_my_model
+from . import test_controllers
+```
+
+---
+
+## Selective Test Runs for CI
+
+```bash
+# Run only the tests for your module (custom tag)
+python odoo-bin -c odoo.conf -d mydb \
+  --test-enable --stop-after-init \
+  --test-tags my_module
+
+# Run a single class
+python odoo-bin -c odoo.conf -d mydb \
+  --test-enable --stop-after-init \
+  --test-tags /my_module/tests/test_my_model.py:TestMyModel
+
+# Run a single method
+python odoo-bin -c odoo.conf -d mydb \
+  --test-enable --stop-after-init \
+  --test-tags /my_module/tests/test_my_model.py:TestMyModel.test_create_record_with_valid_data
+```


### PR DESCRIPTION
### Context

Adds the `odoo-testing` skill (ODSK-SKL-TEST), the sixth Tier 1 skill in the library. Establishes the TDD workflow for Odoo development — Red → Green → Refactor — adapted from the Prowler pattern to Odoo's testing infrastructure (`TransactionCase`, `HttpCase`, `@tagged`).

### Description

- **Skill**: `odoo-testing`
- **Skill ID**: `ODSK-SKL-TEST`
- **Odoo Version**: v16 / v17 / v18
- **Breaking Change**: No

Includes:
- Full TDD cycle (Phase 0 Assessment → Phase 1 RED → Phase 2 GREEN → Phase 3 Triangulation → Phase 4 REFACTOR)
- Asset templates: `common-template.py`, `transaction-case-template.py`, `http-case-template.py`
- Reference: `testing-patterns.md` (assert methods, mocking, v16/v17/v18 compat table)
- `AGENTS.md` updated with `odoo-testing` entry in the Available Skills table

### Odoo Version Compatibility

- [x] N/A — Not version-sensitive (skill covers v16/v17/v18 patterns internally)

### Steps to Review

1. Read `skills/odoo-testing/SKILL.md` — verify TDD phases, `@tagged` reference, and anti-patterns section.
2. Check `assets/` templates for correctness against Odoo testing API.
3. Check `references/testing-patterns.md` for assert methods and v16/v17/v18 compat table.
4. Confirm `AGENTS.md` router table includes `odoo-testing`.
5. Run CI — verify no bare code blocks and no duplicate Skill IDs.

### Checklist

- [x] Skill ID `ODSK-SKL-TEST` is unique across the library.
- [x] All Markdown code blocks have language identifiers.
- [x] `AGENTS.md` updated with router entry for `odoo-testing`.
- [x] Asset templates follow Odoo testing conventions (`TransactionCase`, `HttpCase`, `@tagged`).
- [x] `README.md` not affected (skill library internal change).

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.