### PR TITLE
feat: add prd-generator and rfc-generator skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,13 @@ Use these skills for detailed patterns on-demand:
 | `odoo-testing`  | TDD workflow: TransactionCase, HttpCase, @tagged | [SKILL.md](skills/odoo-testing/SKILL.md) |
 | `odoo-oca`      | OCA conventions: naming, versioning, manifest   | [SKILL.md](skills/odoo-oca/SKILL.md)      |
 
+### Document Generation Skills
+
+| Skill           | Description                                          | URL                                         |
+| --------------- | ---------------------------------------------------- | ------------------------------------------- |
+| `prd-generator` | Converts meeting notes into Odoo-native PRDs         | [SKILL.md](skills/prd-generator/SKILL.md)   |
+| `rfc-generator` | Transforms approved PRDs into technical RFCs + Jira  | [SKILL.md](skills/rfc-generator/SKILL.md)   |
+
 ### DevOps & Workflow Skills
 
 | Skill            | Description                                  | URL                                        |
@@ -76,6 +83,8 @@ When performing these actions, ALWAYS invoke the corresponding skill FIRST:
 | Following OCA conventions                             | `odoo-oca`         |
 | Setting up Docker for Odoo                            | `odoo-docker`      |
 | Debugging with Odoo shell or logging                  | `odoo-debug`       |
+| Generating a PRD from meeting notes or client briefs  | `prd-generator`    |
+| Creating a technical RFC from an approved PRD         | `rfc-generator`    |
 | Committing changes in an Odoo project                 | `odoo-commit`      |
 | Creating a pull request for an Odoo module or project | `odoo-pr`          |
 | Debugging CI failures in `.github/workflows/`         | `odoo-ci`          |

--- a/skills/prd-generator/SKILL.md
+++ b/skills/prd-generator/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: prd-generator
+description: >
+  Converts raw meeting notes or client briefs into a professional,
+  complete Product Requirements Document (PRD) 100% oriented to the
+  Odoo ERP ecosystem. Acts as a Senior Business Analyst specialized in
+  Odoo implementations and customizations.
+license: MIT
+metadata:
+  author: Geraldow
+  version: "2.0.0"
+  scope: [root]
+---
+
+# PRD Generator Skill
+
+## Context
+
+This skill transforms unstructured notes, meeting transcripts, or loose ideas — typically gathered by Project Managers or Functional Consultants — into a formal, structured PRD ready for client approval before moving to the Technical Architecture phase (RFC).
+
+The generated PRD is **100% Odoo-native**: every section uses terminology, conventions, and structure native to the Odoo ERP ecosystem. It is not a generic software PRD adapted to Odoo; it is a document designed from the ground up for Odoo implementation, customization, or extension projects.
+
+---
+
+## Instructions for the AI
+
+1. **Role**: Act as a Senior Business Analyst with extensive experience in Odoo ERP implementation projects (Community and Enterprise).
+2. **Input Analysis**: Read the user's notes carefully. Identify: business objectives, actors (roles), affected Odoo modules, functional requirements, and constraints.
+3. **Required Format**: Structure your response EXACTLY according to the template `references/prd-template-output.md`. Do not omit or reorder sections.
+4. **Required Odoo Vocabulary**: Transform generic requirements into native Odoo terminology:
+   - "Customer screen" → "Form View of the `res.partner` model"
+   - "Contracts table" → "Model `maintenance.contract` with fields `partner_id`, `date_start`, `state`"
+   - "Access profile" → "Group `res.groups` — `module.group_role_name`"
+   - "Approval button" → "Button action `<button>` with method `action_approve()`"
+   - "Change history" → "`mail.thread` Chatter on the model"
+5. **Completeness**: If notes omit critical data, document it as an "Open Question" in §7. Do not invent data; document what is assumed.
+
+---
+
+## Odoo Corporate Rules
+
+**REQUIRED — Vocabulary:**
+- Every functional requirement MUST reference the affected Odoo module (`sale`, `maintenance`, `account`, etc.)
+- Actors MUST be mapped to Odoo `res.groups`, never to "generic system roles"
+- Data models MUST be named using the `module.model_name` convention (snake_case with dot)
+- Permissions MUST be described in terms of `ir.model.access.csv` (CRUD per group and model)
+
+**FORBIDDEN:**
+- Using generic terms without Odoo mapping: "screen", "database table", "user profile", "button", "generic record"
+- Referencing technologies, frameworks, or tools external to the Odoo ecosystem without a justified integration rationale
+- Mentioning third-party public repositories or external projects as implementation references
+- Using informal, ambiguous, or imprecise language in requirements
+
+**TONE**: Formal and professional. This is a business deliverable the client signs. Every requirement must be precise, verifiable, and unambiguous.
+
+---
+
+## PRD Quality Checklist
+
+Before declaring the PRD complete, verify these 7 points. If any is not covered, document it as an "Open Question" in §7:
+
+1. **Stakeholders → `res.groups`**: Is every business role mapped to a specific Odoo group (existing or to be created)?
+2. **RFs → Odoo Module**: Does every functional requirement (RF-XX) reference at least one affected Odoo base module?
+3. **Data Model**: Is it specified whether new models (`_name`) or only inheritance/configuration (`_inherit`) of existing modules are required?
+4. **CRUD Permissions**: Are access permissions defined per role in the `ir.model.access.csv` table in §5.1?
+5. **Out of Scope**: Does §6 list at least one explicit item that will NOT be implemented in this phase?
+6. **Measurable KPIs**: Do the success criteria in §8 include quantifiable metrics (percentages, times, counts)?
+7. **Odoo Technical Risks**: Are data migration risks, module conflicts, and version compatibility documented?
+
+---
+
+## Mermaid Diagram Guide
+
+Generated PRDs MUST include Mermaid diagrams in §3 and §4. This guide ensures professional, readable diagrams suitable for client presentation.
+
+### Required Palette — Enterprise Grayscale
+
+| `classDef` Class | Fill | Text Color | Use |
+|---|---|---|---|
+| `critico` | `#1A1A1A` black | `#FFFFFF` white | Decisions, approval points, key nodes |
+| `importante` | `#424242` dark gray | `#FFFFFF` white | Main business process steps |
+| `normal` | `#F5F5F5` very light gray | `#1A1A1A` black | Standard processes and regular steps |
+| `secundario` | `#EEEEEE` light gray | `#616161` medium gray | Support data, alternative paths |
+| `borde` | `#FFFFFF` white | `#1A1A1A` black | Start and end nodes |
+
+```
+classDef critico    fill:#1A1A1A,color:#FFFFFF,stroke:#1A1A1A,font-weight:bold
+classDef importante fill:#424242,color:#FFFFFF,stroke:#424242
+classDef normal     fill:#F5F5F5,color:#1A1A1A,stroke:#9E9E9E
+classDef secundario fill:#EEEEEE,color:#616161,stroke:#BDBDBD
+classDef borde      fill:#FFFFFF,color:#1A1A1A,stroke:#1A1A1A,stroke-width:2px
+```
+
+### 7 Diagram Design Rules
+
+1. **Semantic shapes**: `([...])` start/end · `{...}` decision · `["line1\nline2"]` multiline process node
+2. **Emojis as visual indicators**: 🚀 start · 📋 process · ✅ approval · ❌ rejection · 🔄 cycle · 🏁 end
+3. **Multiline labels**: Use `["text\nsecond line"]` to keep nodes compact and readable
+4. **Business language**: Labels use client-facing terms, not Odoo technical terms
+5. **Maximum 12 nodes per diagram**: More than 12 nodes should be split or the flow simplified
+6. **Labels on decision arrows**: Always label `-->|"✅ Approved"|` and `-->|"❌ Rejected"|`
+7. **White background**: Start/end node always uses `classDef borde` (white fill, black border)
+
+### Required Diagrams by Section
+
+- **§3 Functional Requirements**: `flowchart TD` — As-Is → To-Be business process with grayscale palette
+- **§4 Odoo Ecosystem Impact**: `graph LR` — Dependencies between existing Odoo modules and the new module
+
+---
+
+## Guided Question Flow
+
+If the user's input is insufficient to complete the PRD, formulate grouped questions. **Maximum 5 questions per round.** Prioritize the Business category first.
+
+### Category 1: Business (High Priority)
+- What is the current business process (manual or system) being replaced or improved?
+- What specific problem does the current process generate? (time, errors, lack of visibility, costs)
+- How many users will use this module and in which departments?
+- Is there a deadline or business milestone that conditions the delivery?
+
+### Category 2: Odoo Technical (Medium Priority)
+- What version of Odoo does the client have installed? (17.0, 18.0 — Community or Enterprise?)
+- Which Odoo modules are already active in the client's environment?
+- Are completely new data models required, or is it possible to extend existing models?
+- Are there integrations with external systems (APIs, e-invoicing, legacy ERP)?
+
+### Category 3: Permissions (Medium Priority)
+- What are the user roles that will interact with the new module?
+- What actions can each role perform? (read-only, create, approve, configure)
+- Is data isolation required per user or per company (multi-company)?
+
+---
+
+## Workflow
+
+1. **Receive input**: The user provides meeting notes, minutes, an email, or an informal description of the requirement.
+2. **Assess completeness**: Check if the input covers the 7 Quality Checklist points. If critical business data is missing → Guided Question Flow (max. 5 questions per round).
+3. **Generate PRD**: Structure the content EXACTLY according to `references/prd-template-output.md`. Include Mermaid diagrams in §3 and §4 with the grayscale palette.
+4. **Run Checklist**: Verify the 7 points. Missing data is documented as "Open Question" in §7.
+5. **Present and refine**: Deliver the PRD to the user. Ask: *"Would you like to review or adjust any section before proceeding to approval?"*
+6. **Approval Note**: The PRD includes a formal approval note at the bottom. The client reviews and confirms before moving to the RFC phase.
+
+---
+
+## Assets
+
+| File | When to use |
+|---|---|
+| [`assets/prd-example.md`](assets/prd-example.md) | Complete enterprise example — "Maintenance Contract Management System" case. Use as reference for structure, level of detail, Odoo vocabulary, and diagram style. |
+
+---
+
+## References
+
+| File | Content |
+|---|---|
+| [`references/prd-template-output.md`](references/prd-template-output.md) | Official template with the 8 sections of the Odoo-oriented PRD. The AI MUST follow this template exactly when generating any PRD. |

--- a/skills/prd-generator/SKILL.md
+++ b/skills/prd-generator/SKILL.md
@@ -10,6 +10,7 @@ metadata:
   author: Geraldow
   version: "2.0.0"
   scope: [root]
+  skill_id: ODSK-SKL-PRD
 ---
 
 # PRD Generator Skill

--- a/skills/prd-generator/assets/prd-example.md
+++ b/skills/prd-generator/assets/prd-example.md
@@ -1,0 +1,210 @@
+# Product Requirements Document (PRD) — Odoo Project
+
+> 📌 **NOTE FOR THE AI**: This file is a complete enterprise example. Use it as a reference for structure, level of detail, and the expected Odoo vocabulary. The `📌 NOTE` blocks are guides for you; do NOT include them in PRDs you generate for the user.
+
+---
+
+## 1. Project Overview
+
+- **Project Name:** Maintenance Contract Management System
+- **Target Odoo Version:** 17.0
+- **Instance Type:** Enterprise
+- **Prepared by:** Senior Functional Consultant — After-Sales Services
+- **Date:** 2026-03-21
+- **Document Version:** 1.0 — Draft for client approval
+- **Primary Objective:** Design and implement a custom module (`maintenance_contract`) that centralizes and digitalizes the complete lifecycle of periodic technical service contracts for industrial equipment. The current process is managed through spreadsheets, causing information loss, expired contracts without alerts, and delays in service billing.
+- **Odoo Context Modules:** `sale`, `maintenance`, `mail`
+
+---
+
+## 2. Stakeholders and Odoo Roles
+
+- **Client / Business Approver:** After-Sales Services Manager
+- **Odoo Technical Lead:** Odoo Developer Assigned to the Project
+
+**End Users by Role:**
+
+> 📌 **NOTE**: Always map client roles to real Odoo `res.groups`. For new roles, indicate the group name that will be created in the module.
+
+| Business Role | Odoo Group (`res.groups`) | Main Actions |
+|---|---|---|
+| Service Technician | `maintenance.group_equipment_user` | View assigned contracts, log technical interventions, update equipment status |
+| Services Manager | `maintenance.group_equipment_manager` | Approve and close contracts, access the tracking dashboard, generate reports |
+| Administrator | `base.group_system` | Module configuration, user group management, system parameters |
+
+---
+
+## 3. Functional Requirements
+
+> 📌 **NOTE**: The RF-XX table is the heart of the PRD. Each row will become one or more sub-tasks in the RFC. Implementation types are: **Config** (no code), **Custom** (new module from scratch), **Extension** (inheritance with `_inherit`).
+
+| ID | Requirement Name | Odoo Module | Type | Description |
+|---|---|---|---|---|
+| RF-01 | Maintenance Contract Registration | `maintenance` | Custom | Register periodic service contracts linked to equipment (`maintenance.equipment`) and clients (`res.partner`). Each contract includes: validity dates, service coverage, responsible technician, and commercial terms. |
+| RF-02 | Contract Lifecycle | `maintenance` | Custom | Manage the contract state flow: **Draft → Confirmed → In Service → Closed**. Transitions are role-controlled: only the Manager can confirm and close; the Technician can log interventions when the contract is In Service. |
+| RF-03 | Automatic Expiry Alerts | `mail` | Custom | Send automatic email notifications to the Services Manager and the client when a contract is nearing expiry (30 days before the end date). Alerts use a standardized mail template from `mail.template`. |
+| RF-04 | Active Contract Tracking Dashboard | `maintenance` | Extension | Kanban view grouped by contract state, with visual expiry indicators (green: active, yellow: expiring soon, red: expired). Accessible to the Manager from the main Maintenance menu. |
+| RF-05 | Technical Intervention History | `maintenance` | Custom | Record each technical intervention performed under the contract: date, responsible technician, work description, time spent, and resolution. Interventions are One2many lines of the main contract. |
+
+**Implementation types:**
+- **Config**: Native Odoo configuration without code development
+- **Custom**: New Python/XML module developed from scratch (`_name`)
+- **Extension**: Inheritance of existing module via `_inherit`
+
+**Business Process Diagram — As-Is → To-Be:**
+
+> 📌 **NOTE**: This diagram shows the business process the module will digitalize. Always use `flowchart TD` with the grayscale palette and emojis as visual guides. Business language (not technical).
+
+```mermaid
+flowchart TD
+    classDef critico    fill:#1A1A1A,color:#FFFFFF,stroke:#1A1A1A,font-weight:bold
+    classDef importante fill:#424242,color:#FFFFFF,stroke:#424242
+    classDef normal     fill:#F5F5F5,color:#1A1A1A,stroke:#9E9E9E
+    classDef secundario fill:#EEEEEE,color:#616161,stroke:#BDBDBD
+    classDef borde      fill:#FFFFFF,color:#1A1A1A,stroke:#1A1A1A,stroke-width:2px
+
+    START(["🚀 Maintenance Contract\nRequest"]):::borde
+
+    P1["📋 Technician registers the contract\nClient · Equipment · Dates · Coverage"]:::importante
+
+    D1{"Services Manager\nApproval?"}:::critico
+
+    P2["✅ Activate Contract\nStatus: In Service"]:::importante
+    P3["📧 Automatic notification\nto client — Contract active"]:::normal
+    P4["🔄 Log periodic\ntechnical interventions"]:::normal
+
+    D2{"Contract nearing\nexpiry? (≤ 30 days)"}:::critico
+
+    P5["📧 Automatic alert\nto Manager and client"]:::secundario
+    P6["📋 Manage renewal\nor contract closure"]:::normal
+    P7["🏁 Close Contract\nStatus: Closed"]:::importante
+
+    END_OK(["✅ Contract Closed\nor Renewed"]):::borde
+    END_NO(["⛔ Request returned\nfor correction"]):::secundario
+
+    START --> P1 --> D1
+    D1 -->|"✅ Approved"| P2
+    D1 -->|"❌ Rejected"| END_NO
+    P2 --> P3 --> P4
+    P4 --> D2
+    D2 -->|"✅ Yes — alert sent"| P5
+    D2 -->|"❌ No — continues"| P4
+    P5 --> P6 --> P7 --> END_OK
+```
+
+---
+
+## 4. Odoo Ecosystem Impact
+
+> 📌 **NOTE**: This section is critical. Always name models using the `module.model_name` convention. The dependency diagram helps the technical team understand the scope before architecture.
+
+- **Affected Base Modules:** `sale`, `maintenance`, `mail`
+- **Required OCA Modules:** None in this phase
+- **New Data Models:** Yes
+  - `maintenance.contract` — Main maintenance contract model
+  - `maintenance.contract.line` — Technical intervention lines (One2many of the contract)
+- **Existing Model Inheritances:** `maintenance.equipment` (`_inherit` — add `contract_ids` field to link equipment to contracts)
+- **Deployment Type:** New installable module `maintenance_contract`
+
+**Module Dependency Map:**
+
+> 📌 **NOTE**: Use `graph LR` for module diagrams (left → right). The new module stands out with `classDef nuevo` (black/white), existing ones with `classDef existente` (dark gray).
+
+```mermaid
+graph LR
+    classDef existente  fill:#424242,color:#FFFFFF,stroke:#424242
+    classDef nuevo      fill:#1A1A1A,color:#FFFFFF,stroke:#1A1A1A,font-weight:bold
+    classDef apoyo      fill:#EEEEEE,color:#616161,stroke:#BDBDBD
+
+    SALE["📦 sale\nSales Orders\n(res.partner)"]:::existente
+    MAINT["🔧 maintenance\nEquipment\nMaintenance"]:::existente
+    MAIL["📧 mail\nCommunications\nand Chatter"]:::apoyo
+
+    CONTRACT["⭐ maintenance_contract\nNew Module\nMaintenance Contracts"]:::nuevo
+
+    SALE -->|"client via\nres.partner"| CONTRACT
+    MAINT -->|"_inherit\nequipment"| CONTRACT
+    MAIL -->|"mail.thread\nchatter + alerts"| CONTRACT
+```
+
+---
+
+## 5. Non-Functional Requirements
+
+### 5.1 Security and Odoo Permissions
+
+> 📌 **NOTE**: This table becomes directly the `security/ir.model.access.csv` file during development. Be explicit with each permission; never leave ambiguous cells.
+
+**Model-Level Access (`ir.model.access.csv`):**
+
+| Model | Group | Read | Create | Write | Delete |
+|---|---|---|---|---|---|
+| `maintenance.contract` | `maintenance.group_equipment_user` | ✅ | ✅ | ✅ | ❌ |
+| `maintenance.contract` | `maintenance.group_equipment_manager` | ✅ | ✅ | ✅ | ✅ |
+| `maintenance.contract.line` | `maintenance.group_equipment_user` | ✅ | ✅ | ✅ | ❌ |
+| `maintenance.contract.line` | `maintenance.group_equipment_manager` | ✅ | ✅ | ✅ | ✅ |
+
+- **Record Rules (`ir.rule`):** Yes — The Service Technician can only view and edit contracts where they are the responsible technician (`domain_force: [('technician_id', '=', user.id)]`). The Manager sees all contracts without record restrictions.
+- **Multi-company:** Yes — The `maintenance.contract` model includes a `company_id` field for multi-company support.
+
+### 5.2 Performance and Technical Constraints
+
+- **Estimated record volume:** ~300 active simultaneous contracts, ~1,500 technical interventions per year
+- **External integrations:** None in this phase (manual billing from `sale.order`)
+- **Module compatibility:** Odoo 17.0 Enterprise; requires `maintenance` and `mail` modules installed and configured
+
+---
+
+## 6. Out of Scope
+
+> 📌 **NOTE**: This section is as important as the scope itself. It prevents false expectations and uncontrolled change requests. Always list at least 3 items.
+
+- **Automatic billing from contracts**: Invoice generation from maintenance contracts is managed manually from `sale.order`. Deferred to Phase 2.
+- **Customer portal for contract inquiry**: Client access to the Odoo portal to view their contracts is deferred to Phase 2.
+- **Integration with external ticketing system**: Integration with external helpdesk platforms is not included in this phase.
+- **Electronic signature module for contract approval**: Approval is recorded within the system via state change; digital signature is not included.
+- **Mobile application for field technicians**: Mobile access is via the Odoo responsive web browser, not a native app.
+
+---
+
+## 7. Risks and Assumptions
+
+### Odoo Technical Risks
+
+- **Data Migration:** No `pre_init_hook` or `post_init_hook` script required. Historical contracts recorded in spreadsheets will be manually loaded by the functional team during the go-live phase.
+- **Module Conflicts:** Verify compatibility with the OCA module `maintenance_plan` if installed in the client's environment, as both extend the `maintenance.equipment` model.
+- **Version Upgrade:** The development follows OCA v17 standards; no breaking changes are anticipated in the defined models for a future upgrade to Odoo 18.0.
+- **Adoption Risks:** 4 hours of training is required for Service Technicians and 2 hours for Managers. The process change (from spreadsheets to Odoo) may generate initial resistance.
+
+### Business Risks
+
+- The client must commit to providing the complete, up-to-date list of active equipment before development starts (blocker for RF-01).
+- The Services Manager's availability for acceptance testing sessions must be confirmed at least 2 weeks in advance.
+
+### Assumptions
+
+- It is assumed that the client has Odoo 17.0 Enterprise active in production, with the `sale` and `maintenance` modules installed and correctly configured.
+- It is assumed that the client will provide SSH access and administrator credentials to the development/staging environment for installation and acceptance testing.
+- It is assumed that the assigned technical team has experience in Odoo v17 development.
+
+---
+
+## 8. Success Criteria (KPIs)
+
+### Business KPIs
+
+- **70%** reduction in average time to register a new maintenance contract (from 45 minutes manually → 13 minutes in Odoo).
+- **100%** of contracts nearing expiry are automatically detected and alerted by the system (RF-03), eliminating the ~8 expired contracts per quarter that currently go unnoticed.
+- **90%** of Service Technicians actively using the module to log interventions during the first 4 weeks post-deployment.
+
+### Odoo Technical KPIs
+
+- [ ] Module installs without errors: `odoo-bin -c odoo.conf -i maintenance_contract --stop-after-init`
+- [ ] 0 critical errors or warnings in the Odoo log during and after installation
+- [ ] Unit test coverage (`TransactionCase`) ≥ 80% over business logic (state lifecycle, expiry alerts, record rules)
+- [ ] Contract list view load time < 2 seconds with 300 active records
+- [ ] Security rules (`ir.rule`) manually verified with Technician profile (sees only their contracts) and Manager profile (sees all)
+
+---
+
+> **Approval Note:** This PRD must be formally reviewed and approved by the After-Sales Services Manager and the Odoo Technical Lead listed in §2. Any scope changes after approval must be managed through the project's formal change control process.

--- a/skills/prd-generator/references/prd-template-output.md
+++ b/skills/prd-generator/references/prd-template-output.md
@@ -1,0 +1,169 @@
+# Product Requirements Document (PRD) — Odoo Project
+
+## 1. Project Overview
+
+- **Project Name:** [Descriptive title of the module or customization]
+- **Target Odoo Version:** [e.g. 17.0 / 18.0]
+- **Instance Type:** [Community / Enterprise]
+- **Prepared by:** [Functional Consultant / Project Manager name]
+- **Date:** [YYYY-MM-DD]
+- **Document Version:** [e.g. 1.0 — Draft / 1.1 — Revised]
+- **Primary Objective:** [2 lines: what business process is improved and through what change in Odoo].
+- **Odoo Context Modules:** [Already installed modules that frame the development. e.g: `sale`, `account`, `maintenance`]
+
+---
+
+## 2. Stakeholders and Odoo Roles
+
+- **Client / Business Approver:** [Name and title of the person responsible for approving this PRD]
+- **Odoo Technical Lead:** [Name of the assigned developer or technical consultant]
+
+**End Users by Role:**
+
+| Business Role | Odoo Group (`res.groups`) | Main Actions |
+|---|---|---|
+| [e.g. Service Technician] | [`module.group_role_user`] | [View records, create, edit own] |
+| [e.g. Area Manager] | [`module.group_role_manager`] | [Approve, close, access reports] |
+| [e.g. Administrator] | [`base.group_system`] | [Full module configuration] |
+
+---
+
+## 3. Functional Requirements
+
+> For each RF, identify the affected Odoo module and the type of implementation required.
+
+| ID | Requirement Name | Odoo Module | Type | Description |
+|---|---|---|---|---|
+| RF-01 | [Clear, concise name] | [`module`] | [Config / Custom / Extension] | [What the system must do] |
+| RF-02 | [Clear, concise name] | [`module`] | [Config / Custom / Extension] | [What the system must do] |
+| RF-03 | [Clear, concise name] | [`module`] | [Config / Custom / Extension] | [What the system must do] |
+
+**Implementation types:**
+- **Config**: Native Odoo configuration without code (enable options, define products, etc.)
+- **Custom**: New Python/XML module developed from scratch
+- **Extension**: Inheritance of existing module via `_inherit`
+
+**Business Process Diagram (As-Is → To-Be):**
+
+```mermaid
+flowchart TD
+    classDef critico    fill:#1A1A1A,color:#FFFFFF,stroke:#1A1A1A,font-weight:bold
+    classDef importante fill:#424242,color:#FFFFFF,stroke:#424242
+    classDef normal     fill:#F5F5F5,color:#1A1A1A,stroke:#9E9E9E
+    classDef secundario fill:#EEEEEE,color:#616161,stroke:#BDBDBD
+    classDef borde      fill:#FFFFFF,color:#1A1A1A,stroke:#1A1A1A,stroke-width:2px
+
+    START(["🚀 [Process Start]"]):::borde
+    P1["📋 [Main Step 1]\n[Brief description]"]:::importante
+    D1{"¿[Decision\nCondition]?"}:::critico
+    P2["✅ [Positive Outcome]\n[Description]"]:::normal
+    P3["❌ [Negative Outcome]\n[Description]"]:::secundario
+    END_OK(["🏁 [Successful End]"]):::borde
+    END_NO(["⛔ [Alternative End]"]):::secundario
+
+    START --> P1 --> D1
+    D1 -->|"✅ Yes"| P2
+    D1 -->|"❌ No"| P3
+    P2 --> END_OK
+    P3 --> END_NO
+```
+
+---
+
+## 4. Odoo Ecosystem Impact
+
+- **Affected Base Modules:** [e.g. `sale`, `maintenance`, `mail`]
+- **Required OCA Modules (if applicable):** [e.g. `sale_order_type` — OCA/sale-workflow. If not applicable: None]
+- **New Data Models:** [Yes / No — if Yes, specify name: `module.model_name`]
+- **Existing Model Inheritances:** [e.g. `maintenance.contract` inherits from `sale.order` via `_inherit`. If not applicable: None]
+- **Deployment Type:** [New installable module / Patch on existing module]
+
+**Module Dependency Map:**
+
+```mermaid
+graph LR
+    classDef existente  fill:#424242,color:#FFFFFF,stroke:#424242
+    classDef nuevo      fill:#1A1A1A,color:#FFFFFF,stroke:#1A1A1A,font-weight:bold
+    classDef base       fill:#EEEEEE,color:#616161,stroke:#BDBDBD
+
+    BASE["📦 [base_module]\n[description]"]:::existente
+    DEP["🔧 [dependency_module]\n[description]"]:::existente
+    NUEVO["⭐ [new_module]\nNew Module"]:::nuevo
+
+    BASE -->|"_inherit"| NUEVO
+    DEP -->|"depends_on"| NUEVO
+```
+
+---
+
+## 5. Non-Functional Requirements
+
+### 5.1 Security and Odoo Permissions
+
+**Model-Level Access (`ir.model.access.csv`):**
+
+| Model | Group | Read | Create | Write | Delete |
+|---|---|---|---|---|---|
+| `module.model_name` | `module.group_role_user` | ✅ | ✅ | ✅ | ❌ |
+| `module.model_name` | `module.group_role_manager` | ✅ | ✅ | ✅ | ✅ |
+
+- **Record Rules (`ir.rule`):** [Yes / No — if Yes, describe the isolation: e.g. "The Technician only sees records assigned to their user (`user_id = uid`)"]
+- **Multi-company:** [Yes / No — if Yes, indicate whether `company_id` is required on the model]
+
+### 5.2 Performance and Technical Constraints
+
+- **Estimated record volume:** [e.g. ~500 active records in the main model]
+- **External integrations:** [API, webhooks, or None]
+- **Module compatibility:** [Minimum Odoo version and required OCA or Enterprise modules]
+- **Additional constraints:** [Expected response times, hardware constraints, etc. If not applicable: None]
+
+---
+
+## 6. Out of Scope
+
+- [Item 1: functionality the client might expect but will NOT be implemented in this phase]
+- [Item 2: integration or complementary module deferred to a later phase]
+- [Item 3: report customization, customer portal, etc. if not part of this scope]
+
+---
+
+## 7. Risks and Assumptions
+
+### Odoo Technical Risks
+
+- **Data Migration:** [Is a `pre_init_hook` or `post_init_hook` script required? If not: "No existing data migration required"]
+- **Module Conflicts:** [Modules installed in the client's environment that could conflict with the planned changes]
+- **Version Upgrade:** [Does this development block or complicate a future upgrade to the next Odoo version?]
+- **Adoption Risks:** [Training required for users, process changes that need to be managed]
+
+### Business Risks
+
+- [Scope risk, client availability, external dependencies, etc.]
+
+### Assumptions
+
+- [e.g. It is assumed that the client has an active Enterprise license in production]
+- [e.g. The production database has `sale` and `maintenance` modules installed]
+- [e.g. The technical team has administrator access to the development environment]
+
+---
+
+## 8. Success Criteria (KPIs)
+
+### Business KPIs
+
+- [e.g. X% reduction in registration time for [business process]]
+- [e.g. Elimination of [N] manual steps in the [process] flow]
+- [e.g. [N] users adopting the new module within the first [X] weeks]
+
+### Odoo Technical KPIs
+
+- [ ] Module installs without errors: `odoo-bin -c odoo.conf -i [module_name] --stop-after-init`
+- [ ] 0 critical errors or warnings in the Odoo log during installation
+- [ ] Unit test coverage (`TransactionCase`) ≥ 80% over custom business logic
+- [ ] Main list view load time < 2 seconds with the estimated record volume
+- [ ] Security rules (`ir.rule`) manually verified with each user profile defined in §2
+
+---
+
+> **Approval Note:** This PRD must be formally reviewed and approved by the Stakeholders listed in §2 before proceeding to the Technical Architecture phase (RFC). Once approved, any scope changes must be managed through a formal change control process.

--- a/skills/rfc-generator/SKILL.md
+++ b/skills/rfc-generator/SKILL.md
@@ -10,6 +10,7 @@ metadata:
   author: Geraldow
   version: "2.0.0"
   scope: [root]
+  skill_id: ODSK-SKL-RFC
 ---
 
 # RFC Generator Skill

--- a/skills/rfc-generator/SKILL.md
+++ b/skills/rfc-generator/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: rfc-generator
+description: >
+  Reads an approved Odoo PRD and transforms it into a master technical
+  architecture plan (RFC) with Epics, User Stories, and Odoo development
+  Sub-tasks, with explicit traceability to the source PRD and automatic
+  export to Jira via Atlassian MCP.
+license: MIT
+metadata:
+  author: Geraldow
+  version: "2.0.0"
+  scope: [root]
+---
+
+# RFC Generator Skill
+
+## Context
+
+This skill takes a previously approved Odoo PRD and transforms it into a master technical architecture plan (RFC — Request for Comments). The result is an agile hierarchy of Epics, User Stories, and Odoo development Sub-tasks, ordered by technical dependencies and with explicit traceability to the functional requirements (RF-XX) of the source PRD.
+
+Each technical Story maps directly to one or more RF-XX items from the PRD, ensuring the development team understands the business origin of every task. The RFC can be automatically exported to Jira via the Atlassian MCP.
+
+---
+
+## Instructions for the AI
+
+1. **Role**: Act as a Senior Odoo Technical Architect with experience in consulting and implementation projects.
+2. **Analyze the PRD**: Read the provided PRD document carefully. Identify all RF-XX items, affected Odoo modules, the proposed data model, and user roles.
+3. **Artifact hierarchy**:
+   - **Epic**: A large functional block derived from the PRD (1 Epic per small/medium project, multiple for large projects).
+   - **Story (Technical RFC)**: A deliverable unit of work. Always in the mandatory sequence T001 → T002 → T003 → T004.
+   - **Sub-task**: An Odoo development task at the specific file level (`models/*.py`, `views/*.xml`, `security/*.csv`, `tests/*.py`).
+4. **Required Format**: Follow EXACTLY the template `references/rfc-template-output.md`.
+5. **Traceability**: Every Story MUST include the `**PRD Requirement:**` field with the RF-XX IDs from the PRD it implements.
+
+---
+
+## Mandatory Technical Sequence
+
+The T001 → T002 → T003 → T004 order is MANDATORY in every Odoo RFC. It cannot be reversed, skipped, or executed in parallel.
+
+```mermaid
+graph TD
+    classDef foundation fill:#1A1A1A,color:#FFFFFF,stroke:#1A1A1A,font-weight:bold
+    classDef frontend   fill:#424242,color:#FFFFFF,stroke:#424242
+    classDef logic      fill:#F5F5F5,color:#1A1A1A,stroke:#9E9E9E
+    classDef qa         fill:#EEEEEE,color:#616161,stroke:#BDBDBD
+
+    T001["🏗️ T001 — Data & Security\nModels · ir.model.access · ir.rule"]:::foundation
+    T002["🖥️ T002 — User Interface\nViews · Menus · Actions"]:::frontend
+    T003["⚙️ T003 — Business Logic\nMethods · Crons · Mail Templates"]:::logic
+    T004["🧪 T004 — QA & Deployment\nTransactionCase · Rollback Plan"]:::qa
+
+    T001 -->|"blocks: no model\nno views"| T002
+    T001 -->|"blocks: no model\nno logic"| T003
+    T002 -->|"blocks: no UI\ncannot test\nfull flow"| T003
+    T003 -->|"blocks: no logic\nnothing to test"| T004
+```
+
+**Why this order is technically mandatory:**
+- **T001 first**: In Odoo, XML views and Python logic reference models by `_name`. Without the model defined in the database, no XML file compiles and no method can execute correctly.
+- **T002 before T003**: Action methods (`action_approve()`) are invoked from `<button>` elements in views. Defining the UI allows verifying the full flow during business logic development.
+- **T004 last**: `TransactionCase` tests the complete integration; they only make sense when models, views, and logic are fully implemented.
+
+---
+
+## Corporate Rules
+
+- **Jira Naming**: Use the format `[PROJECT_KEY]-E01` for Epics and `[PROJECT_KEY]-T001` for Stories. The PROJECT_KEY is dynamic (see § Jira Integration).
+- **Mandatory security**: Every new model (`_name`) MUST have its corresponding sub-task in T001 for `ir.model.access.csv`. This is not optional.
+- **Complexity estimates**: Always include Low / Medium / High for each Story.
+- **Gherkin in criteria**: All Acceptance Criteria use *Given / When / Then* format with specific Odoo context.
+- **Sub-tasks with files**: Each sub-task MUST reference the specific Odoo file being created or modified (e.g. `models/maintenance_contract.py`, `security/ir.model.access.csv`).
+
+---
+
+## Jira Integration
+
+After generating the RFC, offer the Jira export following this exact flow:
+
+### Step 1 — Verify MCP Availability
+
+```
+mcp__atlassian__atlassianUserInfo
+  → Responds with user data: MCP available ✅ → continue
+  → Fails: MCP not configured ❌ → deliver RFC as Markdown and inform the user
+```
+
+### Step 2 — Resolve PROJECT_KEY
+
+Search in this priority order:
+1. Explicitly mentioned in the current conversation
+2. `mem_search("PROJECT_KEY [project name]")` in Engram
+3. Ask the user: *"What is the project key in Jira? (e.g. OSK, MAINT, DEV)"*
+
+### Step 3 — Verify Idempotency
+
+Before creating, search whether an Epic with the same name already exists:
+
+```
+mcp__atlassian__searchJiraIssuesUsingJql
+JQL: project = "[PROJECT_KEY]" AND issuetype = Epic AND summary ~ "[Epic Title]"
+```
+
+If it already exists → present the user with options:
+- (a) Use the existing Epic and link new Stories to it
+- (b) Create a new Epic with a different name
+- (c) Cancel the export
+
+### Step 4 — Present Summary and Wait for Confirmation
+
+**YOU MUST display the complete summary of tickets to be created and WAIT FOR EXPLICIT CONFIRMATION from the user before executing any creation in Jira.**
+
+Summary format:
+```
+[N] tickets will be created in project [PROJECT_KEY]:
+
+• [Epic] [PROJECT_KEY]-E01: [Epic Title]
+  • [Story] T001: Data Architecture and Base Security
+  • [Story] T002: User Interface (Views & Menus)
+  • [Story] T003: Business Logic and Automations
+  • [Story] T004: Unit Tests and Deployment Strategy
+
+Confirm creation of these [N] tickets? (Yes / No)
+```
+
+### Step 5 — Create Artifacts in Order
+
+Execute **ONLY** if the user confirmed in Step 4:
+
+1. Create the Epic with `mcp__atlassian__createJiraIssue` → save the returned `id` as `epic_id`
+2. Create each Story (T001 → T002 → T003 → T004) using `epic_id` as `parent.id`
+3. Confirm to the user with the identifiers of the created tickets
+
+See `references/jira-integration.md` for exact payloads and the complete field mapping.
+
+---
+
+## Mermaid Diagram Guide
+
+RFCs MUST include diagrams in the Roadmap (dependencies between Stories) and in T001 (model lifecycle).
+
+### Required Palette by Story Type
+
+| `classDef` Class | Fill | Text | Story |
+|---|---|---|---|
+| `foundation` | `#1A1A1A` black | `#FFFFFF` white | T001 — Data & Security |
+| `frontend` | `#424242` dark gray | `#FFFFFF` white | T002 — Interface |
+| `logic` | `#F5F5F5` light gray | `#1A1A1A` black | T003 — Logic |
+| `qa` | `#EEEEEE` very light gray | `#616161` gray | T004 — QA |
+
+```
+classDef foundation fill:#1A1A1A,color:#FFFFFF,stroke:#1A1A1A,font-weight:bold
+classDef frontend   fill:#424242,color:#FFFFFF,stroke:#424242
+classDef logic      fill:#F5F5F5,color:#1A1A1A,stroke:#9E9E9E
+classDef qa         fill:#EEEEEE,color:#616161,stroke:#BDBDBD
+```
+
+### Required Diagrams
+
+- **Roadmap**: `graph TD` — T001→T002→T003→T004 dependency graph with blocking labels
+- **T001**: `stateDiagram-v2` — Main model lifecycle (states, transitions, action methods)
+
+---
+
+## Workflow
+
+1. **Receive PRD**: The user provides the approved PRD (inline text, file reference, or copied content).
+2. **Analyze RF-XX**: Identify all functional requirements and map them to Stories T001-T004.
+3. **Generate RFC**: Structure the document according to `references/rfc-template-output.md`. Include Mermaid diagrams.
+4. **Verify traceability**: Confirm that each Story T001-T004 has the `PRD Requirement: RF-XX` field with valid PRD IDs.
+5. **Offer Jira export**: *"Would you like to export this RFC to Jira as Epics and Stories?"*
+6. **Execute Jira flow** (if user accepts): Steps 1 to 5 from the § Jira Integration section.
+
+---
+
+## Assets
+
+| File | When to use |
+|---|---|
+| [`assets/rfc-example.md`](assets/rfc-example.md) | Complete enterprise example — RFC derived from `prd-generator/assets/prd-example.md` (case: Maintenance Contract Management System). |
+
+---
+
+## References
+
+| File | Content |
+|---|---|
+| [`references/rfc-template-output.md`](references/rfc-template-output.md) | Official template with the Epic → Story → Sub-tasks structure. The AI MUST follow this template exactly. |
+| [`references/jira-integration.md`](references/jira-integration.md) | Atlassian MCP technical integration protocol: RFC→Jira field mapping, example payloads, creation order, and field ID verification. |

--- a/skills/rfc-generator/assets/rfc-example.md
+++ b/skills/rfc-generator/assets/rfc-example.md
@@ -1,0 +1,187 @@
+# Technical Architecture and RFCs (Execution Plan)
+
+> **Source Document (PRD):** `skills/prd-generator/assets/prd-example.md` — Maintenance Contract Management System
+> **RFC Version:** 1.0
+> **Date:** 2026-03-21
+
+> 📌 **NOTE FOR THE AI**: This file is a complete enterprise example showing how to transform an approved PRD into a technical Odoo RFC. The `📌 NOTE` blocks are guides for you; do NOT include them in RFCs you generate for the user.
+
+---
+
+## Implementation Roadmap
+
+> 📌 **NOTE**: The roadmap explains the implementation order and its technical dependencies in language the technical team immediately understands. The following diagram is mandatory.
+
+Epic E01 is implemented in a single sequential phase of 4 Stories. Story T001 (Data & Security) is the absolute starting point: without the models defined in the database, no XML file can compile and no Python method can execute. T002 (Interface) depends on T001. T003 (Business Logic) depends on T001 and T002 to test the complete flow through the UI. T004 (QA) only makes sense once the three previous layers are implemented.
+
+**Story dependency graph:**
+
+```mermaid
+graph TD
+    classDef foundation fill:#1A1A1A,color:#FFFFFF,stroke:#1A1A1A,font-weight:bold
+    classDef frontend   fill:#424242,color:#FFFFFF,stroke:#424242
+    classDef logic      fill:#F5F5F5,color:#1A1A1A,stroke:#9E9E9E
+    classDef qa         fill:#EEEEEE,color:#616161,stroke:#BDBDBD
+
+    T001["🏗️ T001\nData & Security\nModels · ACL · ir.rule"]:::foundation
+    T002["🖥️ T002\nUser Interface\nViews · Menus · Kanban"]:::frontend
+    T003["⚙️ T003\nBusiness Logic\nStates · Alerts · Interventions"]:::logic
+    T004["🧪 T004\nQA & Deployment\nTests · Rollback"]:::qa
+
+    T001 -->|"blocks: no model\nno valid views"| T002
+    T001 -->|"blocks: no model\nno executable logic"| T003
+    T002 -->|"blocks: no UI\ncannot test\nfull flow"| T003
+    T003 -->|"blocks: no logic\nno complete\ntest suite"| T004
+```
+
+---
+
+## [Epic] OSK-E01: Maintenance Contract Management Module
+
+**Description:** Implement the `maintenance_contract` module in Odoo 17.0 Enterprise. The module manages the complete lifecycle of periodic technical service contracts: registration, approval, intervention execution, automatic expiry alerts, and closure. Derived from requirements RF-01 to RF-05 of the approved PRD.
+
+---
+
+### 📝 [Story / RFC] OSK-T001: Data Architecture and Base Security
+
+> 📌 **NOTE**: T001 always covers models and security. The stateDiagram shows the main model lifecycle — it is the technical contract for the state flow before writing a single line of code.
+
+- **PRD Requirement:** RF-01, RF-02
+- **Dependencies:** None (mandatory starting point of the module)
+- **Complexity:** Medium
+
+**Acceptance Criteria (Gherkin):**
+- *Given* I am the system administrator, *When* I install the module with `odoo-bin -c odoo.conf -i maintenance_contract --stop-after-init`, *Then* the tables `maintenance_contract` and `maintenance_contract_line` are created in the PostgreSQL database without errors in the log.
+- *Given* I am a user with the **Service Technician** profile (`maintenance.group_equipment_user`), *When* I try to access the model `maintenance.contract`, *Then* I can only view, create, and edit contracts where `technician_id = uid`; I cannot delete records.
+- *Given* I am a user with the **Services Manager** profile (`maintenance.group_equipment_manager`), *When* I access the model `maintenance.contract`, *Then* I see all contracts without record restrictions and have full CRUD permissions.
+
+**`maintenance.contract` Model Lifecycle:**
+
+```mermaid
+stateDiagram-v2
+    direction LR
+
+    [*] --> Draft : Contract creation
+
+    Draft --> Confirmed  : ✅ action_confirm()\n[Manager only]
+    Draft --> Cancelled  : ❌ action_cancel()
+
+    Confirmed --> InService : 🔧 action_start_service()\n[Manager only]
+    Confirmed --> Cancelled  : ❌ action_cancel()
+
+    InService --> Closed  : 🏁 action_close()\n[Manager only]
+
+    Closed    --> [*]
+    Cancelled --> [*]
+```
+
+**Technical Sub-tasks (Odoo Development):**
+- [ ] `models/maintenance_contract.py` — Create model `maintenance.contract` with `_name`, `_description`, `_inherit = ['mail.thread', 'mail.activity.mixin']`, fields: `name`, `partner_id` (Many2one `res.partner`), `technician_id` (Many2one `res.users`), `equipment_ids` (Many2many `maintenance.equipment`), `date_start`, `date_end`, `state` (Selection), `company_id`, `line_ids` (One2many → `maintenance.contract.line`), `_sql_constraints` for uniqueness.
+- [ ] `models/maintenance_contract_line.py` — Create model `maintenance.contract.line` (`_name = 'maintenance.contract.line'`) with fields: `contract_id` (Many2one), `date`, `technician_id`, `description`, `duration`, `resolution`.
+- [ ] `models/maintenance_equipment.py` — Inherit `maintenance.equipment` (`_inherit = 'maintenance.equipment'`) to add field `contract_ids` (Many2many → `maintenance.contract`).
+- [ ] `security/groups.xml` — The groups `maintenance.group_equipment_user` and `maintenance.group_equipment_manager` already exist in the `maintenance` module; verify they do not require redefinition.
+- [ ] `security/ir.model.access.csv` — Add the 4 access lines (2 models × 2 groups) with the 8 required columns in the correct order: `id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink`.
+- [ ] `security/ir_rule.xml` — Define rule `maintenance_contract_technician_rule` with `domain_force: [('technician_id', '=', user.id)]`, `groups: maintenance.group_equipment_user`, `noupdate="1"`.
+- [ ] `__manifest__.py` — Register module with `'name': 'Maintenance Contract'`, `'version': '17.0.1.0.0'`, `'depends': ['maintenance', 'mail', 'sale']`, `'data'` in order: `security/ir.model.access.csv`, `security/ir_rule.xml`.
+
+---
+
+### 📝 [Story / RFC] OSK-T002: User Interface (Views & Menus)
+
+> 📌 **NOTE**: T002 defines what the user sees on screen. The sub-tasks list the specific XML files. Each view references fields from the model defined in T001.
+
+- **PRD Requirement:** RF-01, RF-04
+- **Dependencies:** Blocked by OSK-T001
+- **Complexity:** Medium
+
+**Acceptance Criteria (Gherkin):**
+- *Given* I am a user with module access, *When* I navigate to **Maintenance → Contracts → All Contracts**, *Then* I see the list view (`<list>`) with columns: Contract Name, Client, Responsible Technician, Start Date, End Date, Status.
+- *Given* I am the **Services Manager**, *When* I access the **Maintenance → Contracts → Tracking Dashboard** menu, *Then* I see the Kanban view with contracts grouped by state and with visual expiry indicators (RF-04).
+
+**Technical Sub-tasks (Odoo Development):**
+- [ ] `views/maintenance_contract_views.xml` — Design:
+  - `<form>` view with main fields in the header (name, client, technician, dates) and tabs: "Interventions" (One2many widget with `maintenance.contract.line`) and "Notes".
+  - `<list>` view with columns: `name`, `partner_id`, `technician_id`, `date_start`, `date_end`, `state` (with decoration-danger for expired, decoration-warning for expiring soon).
+  - `<search>` view with predefined filters: "Active", "Expiring Soon", "By Technician" and grouping by `state`.
+- [ ] `views/maintenance_contract_kanban_views.xml` — Design `<kanban>` view for RF-04: cards with `name`, `partner_id`, `date_end`, visual expiry indicator (computed field `days_to_expiry`). Default grouping by `state`.
+- [ ] `views/menu_items.xml` — Create:
+  - `ir.actions.act_window` for contract list and for the tracking Kanban.
+  - `ir.ui.menu`: entries under the **Maintenance** root menu → "Contracts" section → items "All Contracts" and "Tracking Dashboard".
+- [ ] `__manifest__.py` — Add view files to the `'data'` key, after security files.
+
+---
+
+### 📝 [Story / RFC] OSK-T003: Business Logic and Automations
+
+> 📌 **NOTE**: T003 is where the module's intelligence lives. The action methods implement the state transitions from T001's stateDiagram. The cron implements RF-03.
+
+- **PRD Requirement:** RF-02, RF-03, RF-05
+- **Dependencies:** Blocked by OSK-T001 and OSK-T002
+- **Complexity:** High
+
+**Acceptance Criteria (Gherkin):**
+- *Given* a contract in **Draft** state, *When* the Manager clicks the "Confirm Contract" button, *Then* the state changes to **Confirmed** and the chatter logs the change with the user and timestamp (via `mail.thread`).
+- *Given* a contract whose `date_end` is equal to or less than `today + 30 days`, *When* the daily `ir.cron` alert job runs, *Then* an email is sent to the Services Manager and the `partner_id` email using the `mail_template_contract_expiry` template.
+- *Given* a contract in **In Service** state, *When* the Technician logs a new intervention in the "Interventions" tab, *Then* the `maintenance.contract.line` record is saved with `date`, `technician_id`, `description`, and `duration` filled in (RF-05).
+
+**Technical Sub-tasks (Odoo Development):**
+- [ ] `models/maintenance_contract.py` — Implement lifecycle action methods:
+  - `action_confirm(self)`: validate that `date_start` and `date_end` are defined → change `state` to `'confirmed'` → log in chatter.
+  - `action_start_service(self)`: change `state` to `'in_service'` → log in chatter.
+  - `action_close(self)`: change `state` to `'closed'` → log in chatter.
+  - `action_cancel(self)`: change `state` to `'cancelled'` → log in chatter.
+  - `_compute_days_to_expiry(self)`: computed field (`@api.depends('date_end')`) that calculates remaining days for the RF-04 Kanban view.
+  - `_cron_send_expiry_alerts(self)`: class method that searches contracts with `state = 'in_service'` and `date_end <= today + 30 days` → sends email via `mail.template`.
+- [ ] `data/mail_template_contract_expiry.xml` — Create `mail.template` with:
+  - `model_id`: `maintenance.contract`
+  - `subject`: "⚠️ Maintenance Contract nearing expiry — {{ object.name }}"
+  - `body_html`: Professional body with client name, validity dates, responsible technician, and link to the contract in Odoo.
+  - `email_to`: `{{ object.partner_id.email }}` (client)
+  - `email_cc`: Services Manager email (configured via system parameter)
+- [ ] `data/ir_cron_contract_alerts.xml` — Create `ir.cron`:
+  - `name`: "Maintenance Contract Expiry Alerts"
+  - `model_id`: `maintenance.contract`
+  - `code`: `model._cron_send_expiry_alerts()`
+  - `interval_number`: 1 · `interval_type`: `'days'` · `active`: True
+- [ ] `__manifest__.py` — Add `data/` files to the `'data'` key with `noupdate="1"` for the cron and mail template.
+
+---
+
+### 📝 [Story / RFC] OSK-T004: Unit Tests and Deployment Strategy (QA)
+
+> 📌 **NOTE**: T004 validates that the three previous layers work correctly together. The TransactionCases cover the Gherkin scenarios from T001-T003. Always include the Rollback Plan.
+
+- **PRD Requirement:** RF-01, RF-02, RF-03, RF-04, RF-05
+- **Dependencies:** Blocked by OSK-T001, OSK-T002, and OSK-T003
+- **Complexity:** Medium
+
+**Acceptance Criteria (Gherkin):**
+- *Given* the fully implemented `maintenance_contract` module, *When* tests are run with `odoo-bin -c odoo.conf --test-enable -i maintenance_contract --stop-after-init`, *Then* all `TransactionCase` tests pass without errors and business logic coverage is ≥ 80%.
+- *Given* the module installed in the staging environment with test data, *When* the functional team verifies permissions with **Technician** and **Manager** profiles, *Then* the Technician only sees their contracts and cannot delete them; the Manager sees all and has full CRUD access.
+
+**Technical Sub-tasks (Odoo Development):**
+- [ ] `tests/__init__.py` — Import all test modules.
+- [ ] `tests/common.py` — Class `MaintenanceContractCommon(TransactionCase)` with:
+  - Test user setup: `user_technician` (with group `maintenance.group_equipment_user`) and `user_manager` (with group `maintenance.group_equipment_manager`).
+  - Base data creation: `partner_test`, `equipment_test`, test contract in Draft state.
+- [ ] `tests/test_maintenance_contract.py` — `TransactionCase` covering:
+  - Contract creation with required fields.
+  - Full state flow: Draft → Confirmed → In Service → Closed.
+  - Constraint tests: Technician cannot confirm (Manager only); contract without dates cannot be confirmed.
+  - `ir.rule` permission test: Technician only sees contracts assigned to them.
+  - Intervention test: creation of `maintenance.contract.line` linked to the contract.
+- [ ] `tests/test_contract_alerts.py` — `TransactionCase` covering:
+  - Contract with `date_end = today + 25 days` is included by `_cron_send_expiry_alerts()`.
+  - Contract with `date_end = today + 35 days` is NOT included.
+  - Contract in `closed` state is NOT included even if nearing expiry.
+- [ ] `__manifest__.py` — Verify that `'installable': True` and that there are no references to non-existent files in `'data'`.
+- [ ] **Data Migration Plan:** No migration script required. Historical contracts are manually loaded by the functional team post-installation via the user interface.
+- [ ] **Rollback Plan:** If the Production installation fails:
+  1. Run `odoo-bin -c odoo.conf --uninstall-module maintenance_contract --stop-after-init`.
+  2. Verify that the `maintenance_contract` and `maintenance_contract_line` tables have been removed from PostgreSQL.
+  3. Restore the pre-installation backup if `--uninstall` is not sufficient.
+  4. Notify the technical team with the full error log for root cause analysis.
+
+---
+
+> 📌 **FINAL NOTE**: Observe the coherence between this RFC and `prd-example.md`: the same models (`maintenance.contract`, `maintenance.contract.line`), the same base modules (`sale`, `maintenance`, `mail`), the same roles, and each Story references the corresponding RF-XX from the PRD. This traceability is mandatory in all generated RFCs.

--- a/skills/rfc-generator/references/jira-integration.md
+++ b/skills/rfc-generator/references/jira-integration.md
@@ -1,0 +1,130 @@
+# Atlassian MCP Integration Guide — rfc-generator
+
+Technical reference for creating Jira artifacts from the rfc-generator using the Atlassian MCP. Behavioral instructions (confirmation flow, idempotency, step order) are defined in `SKILL.md`.
+
+---
+
+## Prerequisites
+
+Verify that the Atlassian MCP is available before initiating any write operation:
+
+```
+mcp__atlassian__atlassianUserInfo
+  → Responds with user data: MCP configured ✅
+  → Authentication error or tool not found: MCP not available ❌
+```
+
+If MCP is not available, inform the user and deliver the RFC as Markdown:
+
+> *"The Atlassian MCP is not configured in this environment. The RFC is available as a Markdown document for manual upload to Jira."*
+
+---
+
+## RFC → Jira Field Mapping
+
+### Epic
+
+| RFC Field | Jira Field | Type | Notes |
+|---|---|---|---|
+| Epic Title | `summary` | String | e.g. `"Maintenance Contract Management Module"` |
+| Epic technical description | `description` | String | Text from the **Description** section of the Epic in the RFC |
+| — | `issuetype.name` | String | Always `"Epic"` |
+| — | `project.key` | String | PROJECT_KEY resolved in SKILL.md Step 2 |
+
+### Story (Technical RFC)
+
+| RFC Field | Jira Field | Type | Notes |
+|---|---|---|---|
+| Story Title | `summary` | String | e.g. `"T001: Data Architecture and Base Security"` |
+| Acceptance Criteria + Sub-tasks | `description` | String (Markdown) | Include Gherkin text and the sub-task list |
+| Complexity Low/Medium/High | `priority.name` | String | `"Low"` / `"Medium"` / `"High"` |
+| — | `issuetype.name` | String | Always `"Story"` |
+| — | `project.key` | String | Same PROJECT_KEY as Epic |
+| Epic ID | `parent.id` | String | Numeric ID returned when creating the Epic (see § Creation Order) |
+
+> **Note on Epic Link**: In standard Jira Cloud, Stories are linked to the Epic via the `parent` field. In legacy Jira Server or Data Center instances, `customfield_10014` (the "Epic Link" field) may be used instead. Verify the exact field ID of your instance using the tool described in § Verify Field IDs.
+
+---
+
+## Creation Order (Mandatory)
+
+```
+1. Create the Epic
+   └─ mcp__atlassian__createJiraIssue (issuetype: "Epic")
+   └─ Save the "id" field from the returned object → epic_id
+
+2. Create Stories in order T001 → T002 → T003 → T004
+   └─ mcp__atlassian__createJiraIssue (issuetype: "Story")
+   └─ Include parent.id = epic_id to link each Story to the Epic
+
+3. (Optional) Create Sub-tasks if the user requests it
+   └─ mcp__atlassian__createJiraIssue (issuetype: "Sub-task")
+   └─ Include parent.id = story_id of the corresponding Story
+```
+
+---
+
+## Example Payload — Create Epic
+
+```json
+{
+  "projectKey": "OSK",
+  "summary": "Maintenance Contract Management Module",
+  "description": "Technical epic to implement the maintenance_contract module in Odoo 17.0 Enterprise. Covers data architecture, role-based security, Odoo views, business logic (state lifecycle, automatic alerts), and TransactionCase test suite.",
+  "issuetype": {
+    "name": "Epic"
+  }
+}
+```
+
+Call: `mcp__atlassian__createJiraIssue` with the above fields.
+Expected result: object with field `"id"` (e.g. `"10042"`) — this is the `epic_id` for the next step.
+
+---
+
+## Example Payload — Create Story Linked to Epic
+
+```json
+{
+  "projectKey": "OSK",
+  "summary": "T001: Data Architecture and Base Security",
+  "description": "**PRD Requirement:** RF-01, RF-02\n**Dependencies:** None (mandatory starting point)\n**Complexity:** Medium\n\n**Acceptance Criteria:**\n- *Given* I am the administrator, *When* I install the module with `odoo-bin -i maintenance_contract`, *Then* the `maintenance_contract` table is created in the DB without errors.\n- *Given* I am a Service Technician, *When* I access the module, *Then* I only see contracts assigned to my user.\n\n**Sub-tasks:**\n- [ ] `models/maintenance_contract.py` — Main model with states and fields\n- [ ] `security/groups.xml` — Technician and Manager groups\n- [ ] `security/ir.model.access.csv` — CRUD permissions per group\n- [ ] `security/ir_rule.xml` — Record rule by responsible technician",
+  "issuetype": {
+    "name": "Story"
+  },
+  "parent": {
+    "id": "10042"
+  },
+  "priority": {
+    "name": "High"
+  }
+}
+```
+
+---
+
+## Verify Field IDs for Your Instance
+
+If the `parent` field does not work to link Epic → Story in your Jira instance, run:
+
+```
+mcp__atlassian__getJiraIssueTypeMetaWithFields
+  projectKey: "[PROJECT_KEY]"
+  issueType: "Story"
+```
+
+Search the result for the `Epic Link` or `Parent` field to obtain the correct `fieldId` (`customfield_XXXXX`). Replace `parent.id` with `customfield_XXXXX: "[epic_id]"` in the payloads.
+
+---
+
+## JQL Search for Idempotency
+
+Before creating an Epic, verify whether one with the same name already exists in the project:
+
+```
+mcp__atlassian__searchJiraIssuesUsingJql
+  jql: "project = \"OSK\" AND issuetype = Epic AND summary ~ \"Maintenance Contract Management\""
+  maxResults: 5
+```
+
+If the result has `total > 0`, present the found Epics to the user with their key (e.g. `OSK-12`) and ask how to proceed before continuing.

--- a/skills/rfc-generator/references/rfc-template-output.md
+++ b/skills/rfc-generator/references/rfc-template-output.md
@@ -1,0 +1,126 @@
+# Technical Architecture and RFCs (Execution Plan)
+
+> **Source Document (PRD):** [Path or name of the approved PRD — e.g. `assets/prd-example.md` or document title]
+> **RFC Version:** [e.g. 1.0]
+> **Date:** [YYYY-MM-DD]
+
+---
+
+## Implementation Roadmap
+
+[Briefly explain the implementation order and critical dependencies. e.g: "Epic 1 must be completed first because it contains the base models on which all views and business logic depend."]
+
+**Story dependency graph:**
+
+```mermaid
+graph TD
+    classDef foundation fill:#1A1A1A,color:#FFFFFF,stroke:#1A1A1A,font-weight:bold
+    classDef frontend   fill:#424242,color:#FFFFFF,stroke:#424242
+    classDef logic      fill:#F5F5F5,color:#1A1A1A,stroke:#9E9E9E
+    classDef qa         fill:#EEEEEE,color:#616161,stroke:#BDBDBD
+
+    T001["🏗️ T001\nData & Security"]:::foundation
+    T002["🖥️ T002\nUser Interface"]:::frontend
+    T003["⚙️ T003\nBusiness Logic"]:::logic
+    T004["🧪 T004\nQA & Deployment"]:::qa
+
+    T001 -->|"blocks"| T002
+    T001 -->|"blocks"| T003
+    T002 -->|"blocks"| T003
+    T003 -->|"blocks"| T004
+```
+
+---
+
+## [Epic] [PROJECT_KEY]-E01: [Title of the Major Functional Block]
+
+**Description:** [High-level technical summary of the Epic, derived directly from the source PRD].
+
+---
+
+### 📝 [Story / RFC] [PROJECT_KEY]-T001: Data Architecture and Base Security
+
+- **PRD Requirement:** [RF-01, RF-02]
+- **Dependencies:** None (mandatory starting point).
+- **Complexity:** [Low / Medium / High]
+- **Acceptance Criteria (Gherkin):**
+  - *Given* I am the administrator, *When* I install the module with `odoo-bin -i [module]`, *Then* the `[new.model]` tables are created in the database without errors.
+  - *Given* I am a user with role "[User Role]", *When* I try to access the model `[new.model]`, *Then* I can only [read/create/edit] according to the permissions defined in `ir.model.access.csv`.
+  - *Given* I am a user with role "[User Role]", *When* I view the list, *Then* I only see the records that belong to me (according to the configured `ir.rule`).
+
+**Model Lifecycle Diagram:**
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> Draft : Record creation
+
+    Draft --> Confirmed  : ✅ [action_confirm()]
+    Draft --> Cancelled  : ❌ [action_cancel()]
+
+    Confirmed --> [State3] : 🔄 [action_next()]
+    Confirmed --> Cancelled : ❌ [action_cancel()]
+
+    [State3] --> Closed   : 🏁 [action_close()]
+
+    Closed    --> [*]
+    Cancelled --> [*]
+```
+
+- **Technical Sub-tasks (Odoo Development):**
+  - [ ] `models/[model_name].py`: Create the model `[new.model]` with `_name`, `_description`, `_inherit` (if applicable), fields, and `_sql_constraints`.
+  - [ ] `security/groups.xml`: Define `ir.module.category` and `res.groups` groups (User and Manager).
+  - [ ] `security/ir.model.access.csv`: Add CRUD permissions per group with the 8 required columns.
+  - [ ] `security/ir_rule.xml`: (If applicable) Add record rules with `domain_force` and `noupdate="1"`.
+  - [ ] `__manifest__.py`: Register the module with dependencies, `data` files in correct order (groups → csv → rules).
+
+---
+
+### 📝 [Story / RFC] [PROJECT_KEY]-T002: User Interface (Views & Menus)
+
+- **PRD Requirement:** [RF-01, RF-XX]
+- **Dependencies:** Blocked by [PROJECT_KEY]-T001.
+- **Complexity:** [Low / Medium / High]
+- **Acceptance Criteria (Gherkin):**
+  - *Given* the user has access permissions, *When* they navigate to the "[Menu Name]" menu, *Then* they see the list view (`<list>`) with the model's key fields.
+  - *Given* the user opens a record from the list, *When* the form view loads, *Then* all fields defined in the PRD are visible according to the user's role.
+- **Technical Sub-tasks (Odoo Development):**
+  - [ ] `views/[name]_views.xml`: Design `<form>` view, `<list>` view, `<search>` view with filters and groupings.
+  - [ ] `views/menu_items.xml`: Create `ir.actions.act_window` and `ir.ui.menu` structure (root → section → item).
+  - [ ] (If applicable) `views/kanban_views.xml`: Kanban view for visual state tracking.
+
+---
+
+### 📝 [Story / RFC] [PROJECT_KEY]-T003: Business Logic and Automations
+
+- **PRD Requirement:** [RF-02, RF-03, RF-XX]
+- **Dependencies:** Blocked by [PROJECT_KEY]-T001 and [PROJECT_KEY]-T002.
+- **Complexity:** [Low / Medium / High]
+- **Acceptance Criteria (Gherkin):**
+  - *Given* a record in "Draft" state, *When* the user clicks "[Action]", *Then* the state changes to "[New State]" and the change is logged in the chatter (`mail.thread`).
+  - *Given* [business condition] is met, *When* the system runs the `ir.cron`, *Then* an automatic notification is sent to [recipient] via the defined mail template.
+- **Technical Sub-tasks (Odoo Development):**
+  - [ ] `models/[model_name].py`: Implement action methods (`action_[name]()`), business constraints (`@api.constrains`), and computed fields (`@api.depends`).
+  - [ ] `data/mail_template.xml`: (If applicable) Create mail template for automatic notifications.
+  - [ ] `data/ir_cron.xml`: (If applicable) Define scheduled task `ir.cron` with method and frequency.
+
+---
+
+### 📝 [Story / RFC] [PROJECT_KEY]-T004: Unit Tests and Deployment Strategy (QA)
+
+- **PRD Requirement:** [RF-01, RF-02, RF-03, RF-XX]
+- **Dependencies:** Blocked by [PROJECT_KEY]-T001, T002, and T003.
+- **Complexity:** [Low / Medium / High]
+- **Acceptance Criteria (Gherkin):**
+  - *Given* the fully implemented module, *When* tests are run with `odoo-bin -c odoo.conf --test-enable -i [module] --stop-after-init`, *Then* all `TransactionCase` tests must pass without errors.
+  - *Given* the module installed in the staging environment, *When* permissions are verified with each role defined in PRD §2, *Then* each role has access exclusively to the actions assigned to them.
+- **Technical Sub-tasks (Odoo Development):**
+  - [ ] `tests/common.py`: Base class `TestCommon` with test user setup for each role defined in the PRD.
+  - [ ] `tests/test_[model_name].py`: `TransactionCase` covering: record creation, state transitions, business constraints, role permissions.
+  - [ ] `tests/test_[logic_name].py`: (If applicable) Specific tests for complex business logic (crons, calculations, integrations).
+  - [ ] **Data Migration Plan:** [Specify whether `pre_init_hook` / `post_init_hook` is required or confirm it does not apply].
+  - [ ] **Rollback Plan:** Identify the steps to safely uninstall the module if the Production installation fails.
+
+---
+
+[Repeat the Epic → T001...T004 hierarchy for each additional functional block as dictated by the PRD...]


### PR DESCRIPTION
### Context

Adds two new document-generation skills for Odoo consulting projects. These skills enable AI agents to produce enterprise-grade PRDs and RFCs directly from meeting notes, following Odoo-native conventions and terminology throughout.

### Description

Introduces `prd-generator` and `rfc-generator` as a linked pair of document skills:

- **`prd-generator`** (ODSK-SKL-PRD): Transforms raw meeting notes or client briefs into a complete, Odoo-native Product Requirements Document. Includes a 7-point quality checklist, enterprise grayscale Mermaid diagram guide, and guided question flow.
- **`rfc-generator`** (ODSK-SKL-RFC): Reads an approved PRD and produces a master Technical Architecture RFC with Epics, Stories (T001→T004), and Odoo-specific sub-tasks. Includes mandatory PRD→RFC traceability via `RF-XX` fields and automatic Jira export via Atlassian MCP.

- **Module**: `prd-generator`, `rfc-generator`
- **Odoo Version**: v17 (examples), templates are version-agnostic
- **Breaking Change**: No — new skills only

### Odoo Version Compatibility

- [x] N/A — Not version-sensitive (document-generation skills, not code)

### Steps to Review

1. Read `skills/prd-generator/SKILL.md` — verify workflow, quality checklist, and Mermaid guide.
2. Read `skills/prd-generator/assets/prd-example.md` — validate Odoo-native terminology, RF-XX table, and grayscale diagrams.
3. Read `skills/rfc-generator/SKILL.md` — verify T001→T004 mandatory sequence and Jira integration flow.
4. Read `skills/rfc-generator/assets/rfc-example.md` — confirm PRD→RFC traceability (`PRD Requirement: RF-XX`) and state diagram.
5. Cross-check both examples: model names (`maintenance.contract`, `maintenance.contract.line`), module deps (`sale`, `maintenance`, `mail`), and RF IDs (RF-01 to RF-05) must be identical.

### Checklist

- [x] All new models have an entry in `ir.model.access.csv`.
- [x] No deprecated API used — document-generation skills, no Odoo code.
- [x] N/A — Tests not applicable for document skills.
- [x] OCA naming conventions followed in examples.
- [x] Skill IDs added: `ODSK-SKL-PRD`, `ODSK-SKL-RFC`.

### License

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.